### PR TITLE
Add music mood filter to resources page

### DIFF
--- a/public/data/music_moods.json
+++ b/public/data/music_moods.json
@@ -1,0 +1,282 @@
+[
+  {
+    "filename": "welcome to chaos - ross bugden.mp3",
+    "moods": ["chaotic", "intense", "dark"],
+    "source": "web search"
+  },
+  {
+    "filename": "unstoppable force.mp3",
+    "moods": ["heroic", "epic", "intense", "driving", "aggressive"],
+    "source": "web search"
+  },
+  {
+    "filename": "undertale ost spear of justice.mp3",
+    "moods": ["fighting", "energetic", "boss battle", "powerful"],
+    "source": "web search"
+  },
+  {
+    "filename": "totally not a rickroll.mp3",
+    "moods": ["happy", "energetic", "fun"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "toad factory - mario kart wii.mp3",
+    "moods": ["classic", "upbeat", "racing", "energetic"],
+    "source": "web search"
+  },
+  {
+    "filename": "synthatiger - beyond the grid.mp3",
+    "moods": ["synthwave", "electronic", "retro", "energetic", "adventure"],
+    "source": "web search"
+  },
+  {
+    "filename": "sparkling stars.mp3",
+    "moods": ["calm", "dreamy", "relaxing"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "shake down - jules gaia.mp3",
+    "moods": ["energetic", "driving"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "run fast instrumental.mp3",
+    "moods": ["energetic", "action", "upbeat", "motivational", "intense"],
+    "source": "web search"
+  },
+  {
+    "filename": "quo vadis.mp3",
+    "moods": ["classic", "dramatic", "epic", "oratorio"],
+    "source": "web search"
+  },
+  {
+    "filename": "qbedwars music.mp3",
+    "moods": ["gaming", "intense", "action"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "popcorn castle.mp3",
+    "moods": ["playful", "happy", "whimsical"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "playboi carti x yeat type beat - shädöw.mp3",
+    "moods": ["modern", "trap", "intense"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "playboi carti x yeat type beat - sega+.mp3",
+    "moods": ["modern", "trap", "energetic"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "playboi carti x yeat type beat - prey.mp3",
+    "moods": ["modern", "trap", "aggressive"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "playboi carti x yeat type beat - explosion.mp3",
+    "moods": ["modern", "trap", "intense", "aggressive"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "playboi carti x yeat type beat - enough.mp3",
+    "moods": ["modern", "trap", "energetic"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "playboi carti x yeat type beat - black.mp3",
+    "moods": ["modern", "trap", "dark", "intense"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "orange marmalade.mp3",
+    "moods": ["playful", "happy", "fun"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "oh what a whirl - jules gaia.mp3",
+    "moods": ["energetic", "upbeat"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "new world.mp3",
+    "moods": ["adventure", "inspiring", "epic"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "move like this - jules gaia.mp3",
+    "moods": ["energetic", "upbeat", "groovy"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "local forecast - kevin macleod.mp3",
+    "moods": ["upbeat", "jazzy", "energetic", "sprightly", "danceable"],
+    "source": "web search"
+  },
+  {
+    "filename": "king pig and his manic minions.mp3",
+    "moods": ["intense", "fun", "adventure"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "journey through the woods.mp3",
+    "moods": ["adventure", "calm", "mysterious"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "infraction - atlas.mp3",
+    "moods": ["epic", "cinematic", "intense"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "iby - dj b-duke.mp3",
+    "moods": ["electronic", "energetic"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "haunted mansion.mp3",
+    "moods": ["spooky", "mysterious", "eerie", "adventure"],
+    "source": "web search"
+  },
+  {
+    "filename": "happy energetic boogie fun.mp3",
+    "moods": ["happy", "energetic", "fun", "playful", "bouncy"],
+    "source": "web search"
+  },
+  {
+    "filename": "end of a long journey.mp3",
+    "moods": ["adventure", "emotional", "reflective"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "dramatic violin.mp3",
+    "moods": ["dramatic", "intense", "emotional"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "dragon castle___makai symphony - dragon castle_ is under a creative commons (by-nc 3.0) license_ @makai-symphony   music powered by breakingcopyright_    • 🔥 epic battle music .mp3",
+    "moods": ["epic", "fighting", "intense", "orchestral"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "deer immaterial anbr adrian berenguer.mp3",
+    "moods": ["calm", "relaxing", "ambient"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "deep in the forest.mp3",
+    "moods": ["adventure", "calm", "mysterious"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "corneria.mp3",
+    "moods": ["classic", "adventure", "upbeat"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "cjbeards - fire and thunder.mp3",
+    "moods": ["epic", "intense", "dramatic"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "chased by fate.mp3",
+    "moods": ["suspense", "intense", "dramatic"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "chaos construct (by azali).mp3",
+    "moods": ["chaotic", "intense", "dark"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "camellia - the world revolving (camellia remix).mp3",
+    "moods": ["intense", "energetic", "electronic"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "break free.mp3",
+    "moods": ["epic", "inspiring", "adventure"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "blizzard peaks - sonic rush adventure.mp3",
+    "moods": ["adventure", "classic", "energetic"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "black mass.mp3",
+    "moods": ["dark", "ominous", "intense"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "battle of birds and pigs.mp3",
+    "moods": ["fighting", "fun", "adventure"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "battle against an empire.mp3",
+    "moods": ["epic", "fighting", "dramatic"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "background music.mp3",
+    "moods": ["ambient", "calm", "relaxing"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "azali x arcerion - zephaniah.mp3",
+    "moods": ["epic", "intense"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "at the speed of light.mp3",
+    "moods": ["fast", "energetic", "adventure"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "apassionato orchestral dramatic music.mp3",
+    "moods": ["classic", "dramatic", "epic"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "anthony vega - johnny vespa.mp3",
+    "moods": ["classic", "energetic", "adventure"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "adventurous.mp3",
+    "moods": ["adventure", "inspiring", "epic"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "action suspense.mp3",
+    "moods": ["suspense", "intense", "dramatic"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "action suspense 2.mp3",
+    "moods": ["suspense", "intense", "dramatic"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "ace - verdant green swans.mp3",
+    "moods": ["calm", "relaxing", "ambient"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "a shattered illusion.mp3",
+    "moods": ["dramatic", "emotional", "mysterious"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "Windmill Isle - Day.mp3",
+    "moods": ["classic", "adventure", "calm"],
+    "source": "filename inference"
+  },
+  {
+    "filename": "Last Chance - Music for FlameFrags 0.mp3",
+    "moods": ["intense", "action", "gaming"],
+    "source": "filename inference"
+  }
+]

--- a/src/components/resources/MusicMoodFilter.tsx
+++ b/src/components/resources/MusicMoodFilter.tsx
@@ -1,0 +1,121 @@
+import { useState, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { IconSearch, IconX, IconMoodHappy } from '@tabler/icons-react';
+import { MusicMood } from '@/types/music';
+
+interface MusicMoodFilterProps {
+  selectedMoods: string[];
+  onMoodChange: (moods: string[]) => void;
+  moodsData: MusicMood[];
+}
+
+const MusicMoodFilter = ({ selectedMoods, onMoodChange, moodsData }: MusicMoodFilterProps) => {
+  const [moodSearch, setMoodSearch] = useState('');
+
+  const allMoods = useMemo(() => {
+    const moodSet = new Set<string>();
+    moodsData.forEach(item => {
+      item.moods.forEach(mood => moodSet.add(mood));
+    });
+    return Array.from(moodSet).sort();
+  }, [moodsData]);
+
+  const filteredMoods = useMemo(() => {
+    if (!moodSearch) return allMoods;
+    const searchLower = moodSearch.toLowerCase();
+    return allMoods.filter(mood => mood.toLowerCase().includes(searchLower));
+  }, [allMoods, moodSearch]);
+
+  const toggleMood = (mood: string) => {
+    if (selectedMoods.includes(mood)) {
+      onMoodChange(selectedMoods.filter(m => m !== mood));
+    } else {
+      onMoodChange([...selectedMoods, mood]);
+    }
+  };
+
+  const clearMoods = () => {
+    onMoodChange([]);
+    setMoodSearch('');
+  };
+
+  if (allMoods.length === 0) return null;
+
+  return (
+    <div className="h-full flex flex-col bg-card/50 border border-border rounded-lg pixel-corners overflow-hidden">
+      <div className="p-3 border-b border-border">
+        <h3 className="text-sm font-vt323 text-muted-foreground mb-2 flex items-center gap-2">
+          <IconMoodHappy className="h-4 w-4 text-cow-purple" />
+          Mood Filter
+        </h3>
+        
+        <div className="relative mb-2">
+          <IconSearch className="absolute left-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search moods..."
+            value={moodSearch}
+            onChange={(e) => setMoodSearch(e.target.value)}
+            className="pl-8 h-8 text-sm pixel-input"
+          />
+          {moodSearch && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="absolute right-1 top-1/2 transform -translate-y-1/2 h-6 w-6"
+              onClick={() => setMoodSearch('')}
+            >
+              <IconX className="h-3 w-3" />
+            </Button>
+          )}
+        </div>
+        
+        {selectedMoods.length > 0 && (
+          <div className="flex items-center justify-between bg-cow-purple/10 px-2 py-1.5 rounded border border-cow-purple/20">
+            <span className="text-xs text-cow-purple">
+              {selectedMoods.length} selected
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-5 text-xs text-cow-purple hover:text-cow-purple"
+              onClick={clearMoods}
+            >
+              Clear
+            </Button>
+          </div>
+        )}
+      </div>
+      
+      <ScrollArea className="flex-1">
+        <div className="p-2">
+          {filteredMoods.map(mood => (
+            <div
+              key={mood}
+              className={`
+                flex items-center gap-2 py-1.5 px-2 rounded-md cursor-pointer mb-1
+                transition-colors duration-150
+                ${selectedMoods.includes(mood) 
+                  ? 'bg-cow-purple/20 text-cow-purple' 
+                  : 'hover:bg-accent/50'
+                }
+              `}
+              onClick={() => toggleMood(mood)}
+            >
+              <span className="text-sm capitalize">{mood}</span>
+            </div>
+          ))}
+          
+          {filteredMoods.length === 0 && moodSearch && (
+            <div className="text-center py-8 text-muted-foreground text-sm">
+              No moods match your search
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+};
+
+export default MusicMoodFilter;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -91,6 +91,7 @@ const normalizeApiResource = (item: ApiResource, category: string): Resource | n
     image_url: undefined,
     software: undefined,
     description: undefined,
+    filename: item.filename,
   };
 };
 

--- a/src/pages/ResourcesHub.tsx
+++ b/src/pages/ResourcesHub.tsx
@@ -6,6 +6,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 import { toast } from 'sonner';
 import { useResources } from '@/hooks/useResources';
 import { Resource } from '@/types/resources';
+import { MusicMood } from '@/types/music';
 import ResourceFilters from '@/components/resources/ResourceFilters';
 import SortSelector from '@/components/resources/SortSelector';
 import ResourcesList from '@/components/resources/ResourcesList';
@@ -72,7 +73,7 @@ const ResourcesHub = () => {
   const isMcIconsView = selectedCategory === 'minecraft-icons';
   const isMusicView = selectedCategory === 'music';
 
-  const [musicMoodsData, setMusicMoodsData] = useState<Array<{ filename: string; moods: string[] }>>([]);
+  const [musicMoodsData, setMusicMoodsData] = useState<MusicMood[]>([]);
 
   useEffect(() => {
     if (isMusicView && musicMoodsData.length === 0) {

--- a/src/pages/ResourcesHub.tsx
+++ b/src/pages/ResourcesHub.tsx
@@ -12,6 +12,7 @@ import ResourcesList from '@/components/resources/ResourcesList';
 import FavoritesTab from '@/components/resources/FavoritesTab';
 import CreatorPacksTab from '@/components/resources/CreatorPacksTab';
 import MusicPacksTab from '@/components/resources/MusicPacksTab';
+import MusicMoodFilter from '@/components/resources/MusicMoodFilter';
 import McSoundsBrowser from '@/components/resources/McSoundsBrowser';
 import McIconsBrowser from '@/components/resources/McIconsBrowser';
 import AuthDialog from '@/components/auth/AuthDialog';
@@ -33,6 +34,7 @@ const ResourcesHub = () => {
   const [showScrollTop, setShowScrollTop] = useState(false);
   const [authDialogOpen, setAuthDialogOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<'resources' | 'favorites' | 'creator-packs' | 'music-packs'>('resources');
+  const [selectedMoods, setSelectedMoods] = useState<string[]>([]);
 
 
   const {
@@ -66,6 +68,31 @@ const ResourcesHub = () => {
 
   const isMcSoundsView = selectedCategory === 'mcsounds';
   const isMcIconsView = selectedCategory === 'minecraft-icons';
+  const isMusicView = selectedCategory === 'music';
+
+  const [musicMoodsData, setMusicMoodsData] = useState<Array<{ filename: string; moods: string[] }>>([]);
+
+  useEffect(() => {
+    if (isMusicView && musicMoodsData.length === 0) {
+      fetch('/data/music_moods.json')
+        .then(res => res.json())
+        .then(data => setMusicMoodsData(data))
+        .catch(err => console.error('Failed to load music moods:', err));
+    }
+  }, [isMusicView, musicMoodsData.length]);
+
+  const moodFilteredResources = useMemo(() => {
+    if (!isMusicView || selectedMoods.length === 0) return filteredResources;
+
+    const moodsMap = new Map(musicMoodsData.map(item => [item.filename.toLowerCase(), item.moods]));
+
+    return filteredResources.filter(resource => {
+      const filename = (resource.filename || resource.title).toLowerCase();
+      const resourceMoods = moodsMap.get(filename);
+      if (!resourceMoods) return false;
+      return selectedMoods.some(mood => resourceMoods.includes(mood));
+    });
+  }, [filteredResources, isMusicView, selectedMoods, musicMoodsData]);
 
   const mcsoundsResourceCount = useMemo(() => {
     if (!isMcSoundsView) return {};
@@ -107,6 +134,12 @@ const ResourcesHub = () => {
       window.removeEventListener('showFavorites', handleShowFavorites);
     };
   }, []);
+
+  useEffect(() => {
+    if (selectedCategory !== 'music') {
+      setSelectedMoods([]);
+    }
+  }, [selectedCategory]);
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
@@ -163,7 +196,7 @@ const ResourcesHub = () => {
 
       <ResourcesList
         resources={resources}
-        filteredResources={filteredResources}
+        filteredResources={isMusicView ? moodFilteredResources : filteredResources}
         isLoading={isLoading}
         isSearching={isSearching}
         selectedCategory={selectedCategory}
@@ -301,30 +334,43 @@ const ResourcesHub = () => {
                   exit={{ opacity: 0, x: 20 }}
                   transition={{ duration: 0.3 }}
                 >
-                  {(isMcSoundsView || isMcIconsView) && !isMobile ? (
+                  {(isMcSoundsView || isMcIconsView || isMusicView) && !isMobile ? (
                     <div className="flex gap-6 max-w-7xl mx-auto">
+                      {isMusicView && (
+                        <div className="w-64 flex-shrink-0">
+                          <div className="sticky top-28 h-[calc(100vh-8rem)]">
+                            <MusicMoodFilter
+                              selectedMoods={selectedMoods}
+                              onMoodChange={setSelectedMoods}
+                              moodsData={musicMoodsData}
+                            />
+                          </div>
+                        </div>
+                      )}
                       <div className="flex-1 min-w-0">
                         {renderContent()}
                       </div>
-                      <div className="w-80 flex-shrink-0">
-                        <div className="sticky top-28 h-[calc(100vh-8rem)]">
-                          {isMcSoundsView ? (
-                            <McSoundsBrowser
-                              subcategories={availableSubcategories}
-                              selectedSubcategory={selectedSubcategory}
-                              onSubcategoryChange={handleSubcategoryChange}
-                              resourceCount={mcsoundsResourceCount}
-                            />
-                          ) : (
-                            <McIconsBrowser
-                              subcategories={availableSubcategories}
-                              selectedSubcategory={selectedSubcategory}
-                              onSubcategoryChange={handleSubcategoryChange}
-                              resourceCount={mciconsResourceCount}
-                            />
-                          )}
+                      {(isMcSoundsView || isMcIconsView) && (
+                        <div className="w-80 flex-shrink-0">
+                          <div className="sticky top-28 h-[calc(100vh-8rem)]">
+                            {isMcSoundsView ? (
+                              <McSoundsBrowser
+                                subcategories={availableSubcategories}
+                                selectedSubcategory={selectedSubcategory}
+                                onSubcategoryChange={handleSubcategoryChange}
+                                resourceCount={mcsoundsResourceCount}
+                              />
+                            ) : (
+                              <McIconsBrowser
+                                subcategories={availableSubcategories}
+                                selectedSubcategory={selectedSubcategory}
+                                onSubcategoryChange={handleSubcategoryChange}
+                                resourceCount={mciconsResourceCount}
+                              />
+                            )}
+                          </div>
                         </div>
-                      </div>
+                      )}
                     </div>
                   ) : (
                     <div className="max-w-4xl mx-auto">

--- a/src/pages/ResourcesHub.tsx
+++ b/src/pages/ResourcesHub.tsx
@@ -17,7 +17,8 @@ import McSoundsBrowser from '@/components/resources/McSoundsBrowser';
 import McIconsBrowser from '@/components/resources/McIconsBrowser';
 import AuthDialog from '@/components/auth/AuthDialog';
 import { Button } from '@/components/ui/button';
-import { IconArrowUp, IconHeart, IconSearch, IconPackage, IconMusic } from '@tabler/icons-react';
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
+import { IconArrowUp, IconHeart, IconSearch, IconPackage, IconMusic, IconMoodHappy, IconFilter } from '@tabler/icons-react';
 import { Helmet } from "react-helmet-async";
 
 
@@ -35,6 +36,7 @@ const ResourcesHub = () => {
   const [authDialogOpen, setAuthDialogOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<'resources' | 'favorites' | 'creator-packs' | 'music-packs'>('resources');
   const [selectedMoods, setSelectedMoods] = useState<string[]>([]);
+  const [mobileMoodFilterOpen, setMobileMoodFilterOpen] = useState(false);
 
 
   const {
@@ -192,6 +194,42 @@ const ResourcesHub = () => {
         <p className="text-xs text-center text-muted-foreground mb-6 -mt-4 opacity-50 hover:opacity-100 transition-opacity">
           Powered by Hamburger API
         </p>
+      )}
+
+      {isMusicView && isMobile && (
+        <div className="mb-4">
+          <Sheet open={mobileMoodFilterOpen} onOpenChange={setMobileMoodFilterOpen}>
+            <SheetTrigger asChild>
+              <Button variant="outline" size="sm" className="w-full pixel-corners">
+                <IconFilter className="h-4 w-4 mr-2" />
+                Filter by Mood
+                {selectedMoods.length > 0 && (
+                  <span className="ml-2 bg-cow-purple text-white text-xs px-1.5 py-0.5 rounded">
+                    {selectedMoods.length}
+                  </span>
+                )}
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="bottom" className="h-[70vh] pixel-corners">
+              <div className="h-full py-2">
+                <h3 className="text-lg font-vt323 mb-4 flex items-center gap-2">
+                  <IconMoodHappy className="h-5 w-5 text-cow-purple" />
+                  Filter by Mood
+                </h3>
+                <MusicMoodFilter
+                  selectedMoods={selectedMoods}
+                  onMoodChange={(moods) => {
+                    setSelectedMoods(moods);
+                    if (moods.length === 0) {
+                      setMobileMoodFilterOpen(false);
+                    }
+                  }}
+                  moodsData={musicMoodsData}
+                />
+              </div>
+            </SheetContent>
+          </Sheet>
+        </div>
       )}
 
       <ResourcesList

--- a/src/types/music.ts
+++ b/src/types/music.ts
@@ -1,0 +1,5 @@
+export interface MusicMood {
+  filename: string;
+  moods: string[];
+  source: string;
+}

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -15,6 +15,7 @@ export interface Resource {
   download_count?: number;
   created_at?: string;
   updated_at?: string;
+  filename?: string;
 }
 
 export const getResourceUrl = (resource: Resource): string => {


### PR DESCRIPTION
- Add filename field to Resource type for matching music files
- Update normalizeApiResource to preserve filename from API
- Create MusicMoodFilter component with search and list layout
- Add music_moods.json data file with mood mappings
- Position mood filter as left sidebar on music category view
- Match design with site's pixel/blocky style (pixel-corners, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mood-based filtering for music resources. Users can now discover and filter music tracks by selecting mood tags from a searchable list. The new filter in the Music category sidebar provides a search field, selectable mood options, and a clear button to reset all selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->