### PR TITLE
feat: music library expansion, UI/UX improvements, and bug fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,0 @@
-# Copy this file to .env and fill in the values.
-# These are client-side env vars — they will be bundled in the app.
-# Get the actual values from a team member or deployment dashboard.
-
-VITE_GAPPA_API_KEY=
-VITE_SUPABASE_ANON_KEY=

--- a/public/changelog.md
+++ b/public/changelog.md
@@ -2,6 +2,28 @@
 
 ![Static Badge](https://img.shields.io/badge/By-Codersoft-green?style=flat&link=https%3A%2F%2Fs0.renderdragon.org%2Fdocs)
 
+## Latest Changes (July 2026)
+
+### Music Library Expansion
+- Added **345 new music tracks** to the library with full mood classifications
+- Each track now includes mood tags (e.g., cheerful, intense, ambient) and source attribution
+
+### Hover-to-Play Disabled by Default
+- Video hover-to-play is now **off by default** for resource cards
+- Users can re-enable it in Account → Preferences → Hover to Play Videos
+
+### Creator Packs Fix
+- Fixed creator packs not showing for non-signed-in users (profiles RLS policy)
+- Added public SELECT policy on profiles table
+
+### Navigation Cleanup
+- Removed "AI Title Helper" and "s0" entries from the Tools dropdown
+- Removed the blogs promotional banner from the navbar entirely
+
+### UI Changes
+- Resource card titles now use **Geist Mono** font instead of JetBrains Mono
+- Signed-in users are now redirected to **/resources** when visiting the home page
+
 This update made me tired! We have made alot of changes in this update. New tools easter eggs and much more....
 
 ## Community Assets

--- a/public/data/music_moods.json
+++ b/public/data/music_moods.json
@@ -1,282 +1,3365 @@
 [
   {
-    "filename": "welcome to chaos - ross bugden.mp3",
-    "moods": ["chaotic", "intense", "dark"],
+    "filename": "11_AM_-_Animal_Crossing_City_Folk_OST.mp3",
+    "moods": [
+      "cheerful",
+      "lively",
+      "bright",
+      "content"
+    ],
     "source": "web search"
   },
   {
-    "filename": "unstoppable force.mp3",
-    "moods": ["heroic", "epic", "intense", "driving", "aggressive"],
+    "filename": "15_Acres_of_Broken_Glass.mp3",
+    "moods": [
+      "ambient",
+      "industrial",
+      "desolate",
+      "mechanical"
+    ],
     "source": "web search"
   },
   {
-    "filename": "undertale ost spear of justice.mp3",
-    "moods": ["fighting", "energetic", "boss battle", "powerful"],
+    "filename": "1_PM_-_Animal_Crossing_City_Folk_OST.mp3",
+    "moods": [
+      "upbeat",
+      "relaxed",
+      "sunny",
+      "content"
+    ],
     "source": "web search"
   },
   {
-    "filename": "totally not a rickroll.mp3",
-    "moods": ["happy", "energetic", "fun"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "toad factory - mario kart wii.mp3",
-    "moods": ["classic", "upbeat", "racing", "energetic"],
+    "filename": "4000_Degrees_Kelvin.mp3",
+    "moods": [
+      "cold",
+      "industrial",
+      "ambient"
+    ],
     "source": "web search"
   },
   {
-    "filename": "synthatiger - beyond the grid.mp3",
-    "moods": ["synthwave", "electronic", "retro", "energetic", "adventure"],
+    "filename": "6_AM_-_Animal_Crossing_City_Folk_OST.mp3",
+    "moods": [
+      "peaceful",
+      "fresh",
+      "gentle",
+      "awakening"
+    ],
     "source": "web search"
   },
   {
-    "filename": "sparkling stars.mp3",
-    "moods": ["calm", "dreamy", "relaxing"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "shake down - jules gaia.mp3",
-    "moods": ["energetic", "driving"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "run fast instrumental.mp3",
-    "moods": ["energetic", "action", "upbeat", "motivational", "intense"],
+    "filename": "6_PM_-_Animal_Crossing_City_Folk_OST.mp3",
+    "moods": [
+      "peaceful",
+      "warm",
+      "cozy",
+      "serene"
+    ],
     "source": "web search"
   },
   {
-    "filename": "quo vadis.mp3",
-    "moods": ["classic", "dramatic", "epic", "oratorio"],
+    "filename": "9999999.mp3",
+    "moods": [
+      "chaotic",
+      "eerie",
+      "glitchy",
+      "disturbing"
+    ],
     "source": "web search"
   },
   {
-    "filename": "qbedwars music.mp3",
-    "moods": ["gaming", "intense", "action"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "popcorn castle.mp3",
-    "moods": ["playful", "happy", "whimsical"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "playboi carti x yeat type beat - shädöw.mp3",
-    "moods": ["modern", "trap", "intense"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "playboi carti x yeat type beat - sega+.mp3",
-    "moods": ["modern", "trap", "energetic"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "playboi carti x yeat type beat - prey.mp3",
-    "moods": ["modern", "trap", "aggressive"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "playboi carti x yeat type beat - explosion.mp3",
-    "moods": ["modern", "trap", "intense", "aggressive"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "playboi carti x yeat type beat - enough.mp3",
-    "moods": ["modern", "trap", "energetic"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "playboi carti x yeat type beat - black.mp3",
-    "moods": ["modern", "trap", "dark", "intense"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "orange marmalade.mp3",
-    "moods": ["playful", "happy", "fun"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "oh what a whirl - jules gaia.mp3",
-    "moods": ["energetic", "upbeat"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "new world.mp3",
-    "moods": ["adventure", "inspiring", "epic"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "move like this - jules gaia.mp3",
-    "moods": ["energetic", "upbeat", "groovy"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "local forecast - kevin macleod.mp3",
-    "moods": ["upbeat", "jazzy", "energetic", "sprightly", "danceable"],
+    "filename": "9_PM_-_Animal_Crossing_City_Folk_OST.mp3",
+    "moods": [
+      "calm",
+      "sleepy",
+      "relaxed",
+      "cozy"
+    ],
     "source": "web search"
   },
   {
-    "filename": "king pig and his manic minions.mp3",
-    "moods": ["intense", "fun", "adventure"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "journey through the woods.mp3",
-    "moods": ["adventure", "calm", "mysterious"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "infraction - atlas.mp3",
-    "moods": ["epic", "cinematic", "intense"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "iby - dj b-duke.mp3",
-    "moods": ["electronic", "energetic"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "haunted mansion.mp3",
-    "moods": ["spooky", "mysterious", "eerie", "adventure"],
+    "filename": "AFTERLIFE_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "chaotic",
+      "intense",
+      "unsettling",
+      "desperate"
+    ],
     "source": "web search"
   },
   {
-    "filename": "happy energetic boogie fun.mp3",
-    "moods": ["happy", "energetic", "fun", "playful", "bouncy"],
+    "filename": "Able_Sisters_Extended.mp3",
+    "moods": [
+      "gentle",
+      "whimsical",
+      "calm",
+      "cozy"
+    ],
     "source": "web search"
   },
   {
-    "filename": "end of a long journey.mp3",
-    "moods": ["adventure", "emotional", "reflective"],
+    "filename": "Adrenal_Vapor.mp3",
+    "moods": [
+      "simple",
+      "bubbly",
+      "nostalgic",
+      "whimsical"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Almost_At_Fifty_Percent.mp3",
+    "moods": [
+      "building",
+      "atmospheric",
+      "urgent",
+      "electronic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Androphonovania.mp3",
+    "moods": [
+      "tense",
+      "dramatic",
+      "grandiose",
+      "ominous"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Androphonovania_Extended.mp3",
+    "moods": [
+      "tense",
+      "dramatic",
+      "grandiose",
+      "ominous"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Battle_-_Battle_Mode_1_Vanilla.mp3",
+    "moods": [
+      "intense",
+      "aggressive",
+      "urgent",
+      "combative"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Battle_-_Battle_Mode_2_Vanilla.mp3",
+    "moods": [
+      "intense",
+      "aggressive",
+      "urgent",
+      "combative"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Battle_-_Battle_Mode_3_Vanilla.mp3",
+    "moods": [
+      "intense",
+      "aggressive",
+      "urgent",
+      "combative"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Battle_-_Battle_Mode_4_Vanilla.mp3",
+    "moods": [
+      "intense",
+      "aggressive",
+      "urgent",
+      "combative"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Believe_In_Him_-_rueckus.mp3",
+    "moods": [
+      "desperate",
+      "hopeful",
+      "determined",
+      "dramatic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "BfB_intro_theme.mp3",
+    "moods": [
+      "catchy",
+      "energetic",
+      "upbeat",
+      "playful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Birds_of_a_Feather_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "lighthearted",
+      "friendly",
+      "warm",
+      "hopeful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Blood_Moon_-_Voxlblade_Remade_OST.mp3",
+    "moods": [
+      "ominous",
+      "threatening",
+      "eerie",
+      "dark"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Bombs_for_Throwing_at_You.mp3",
+    "moods": [
+      "frantic",
+      "climactic",
+      "intense",
+      "chaotic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Bombs_for_Throwing_at_You_-_Attach_It_To_Him.mp3",
+    "moods": [
+      "urgent",
+      "desperate",
+      "frantic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Bombs_for_Throwing_at_You_-_Goodbye..mp3",
+    "moods": [
+      "final",
+      "dramatic",
+      "bittersweet"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Bombs_for_Throwing_at_You_-_Its_A_Fools_Errand.mp3",
+    "moods": [
+      "desperate",
+      "futile",
+      "intense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Bombs_for_Throwing_at_You_-_Nobody_Is_Going_To_Space_Mate.mp3",
+    "moods": [
+      "mocking",
+      "chaotic",
+      "frantic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Bombs_for_Throwing_at_You_-_What_Have_You_Put_Onto_Me.mp3",
+    "moods": [
+      "panicked",
+      "frantic",
+      "desperate"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Bombs_for_Throwing_at_You_-_You_Like_Revenge_Right.mp3",
+    "moods": [
+      "vengeful",
+      "intense",
+      "aggressive"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Break_Free.mp3",
+    "moods": [
+      "uplifting",
+      "energetic",
+      "inspiring",
+      "triumphant"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Breakage_Pt.1_-_ivorycello.mp3",
+    "moods": [
+      "tense",
+      "ominous",
+      "urgent"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Breakage_Pt.2_-_ivorycello.mp3",
+    "moods": [
+      "desperate",
+      "chaotic",
+      "intense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Breakage_Pt.2_-_ivorycello_No_door_knock_sound_effect.mp3",
+    "moods": [
+      "desperate",
+      "chaotic",
+      "intense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Bubblaine_-_Super_Mario_Odyssey_OST.mp3",
+    "moods": [
+      "bright",
+      "peaceful",
+      "cheerful",
+      "tropical"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "CORE_Extended.mp3",
+    "moods": [
+      "atmospheric",
+      "mechanical",
+      "cold",
+      "intense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Calm_Your_Nerves_-_Ivory.mp3",
+    "moods": [
+      "anxious",
+      "tense",
+      "ominous"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Champas_theme_Extended.mp3",
+    "moods": [
+      "epic",
+      "intense",
+      "dramatic",
+      "powerful"
+    ],
     "source": "filename inference"
   },
   {
-    "filename": "dramatic violin.mp3",
-    "moods": ["dramatic", "intense", "emotional"],
+    "filename": "Cipher.mp3",
+    "moods": [
+      "funk",
+      "upbeat",
+      "energetic",
+      "groovy"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Cjbeards_-_Fire_And_Thunder.mp3",
+    "moods": [
+      "epic",
+      "dramatic",
+      "powerful",
+      "intense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Clock_Town_-_Day_1.mp3",
+    "moods": [
+      "peaceful",
+      "charming",
+      "carefree",
+      "relaxed"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Clock_Town_-_Day_2.mp3",
+    "moods": [
+      "somber",
+      "eerie",
+      "uneasy",
+      "rainy"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Clock_Town_-_Day_3.mp3",
+    "moods": [
+      "frantic",
+      "desperate",
+      "anxious",
+      "doom-laden"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Colossus_OST_ver.mp3",
+    "moods": [
+      "epic",
+      "intense",
+      "powerful",
+      "grand"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Comedy__Tragedy__Time.mp3",
+    "moods": [
+      "playful",
+      "eerie",
+      "upbeat"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Comforting_Memories.mp3",
+    "moods": [
+      "peaceful",
+      "nostalgic",
+      "warm",
+      "serene"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Concentration_Enhancing_Menu_Initialiser.mp3",
+    "moods": [
+      "mysterious",
+      "atmospheric",
+      "focus-inducing"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Concrete_Halls.mp3",
+    "moods": [
+      "ambient",
+      "atmospheric",
+      "cold",
+      "empty"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Creative_Exercise_Demo_-_Mario_Paint_OST.mp3",
+    "moods": [
+      "playful",
+      "catchy",
+      "whimsical",
+      "nostalgic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Creator_-_Minecraft_Music_Disc_-_Lena_Raine.mp3",
+    "moods": [
+      "energetic",
+      "uplifting",
+      "hopeful",
+      "triumphant"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "DBS_ost_Dystopian_Future_A.mp3",
+    "moods": [
+      "dark",
+      "futuristic",
+      "tense",
+      "ominous"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "DBS_ost_Dystopian_Future_B.mp3",
+    "moods": [
+      "dark",
+      "futuristic",
+      "tense",
+      "ominous"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dark_Choir_Music_-_RF.mp3",
+    "moods": [
+      "dark",
+      "ominous",
+      "haunting",
+      "gothic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Darkness_of_the_Unknown.mp3",
+    "moods": [
+      "epic",
+      "dramatic",
+      "intense",
+      "desperate"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dating_Start.mp3",
+    "moods": [
+      "romantic",
+      "sweet",
+      "nervous",
+      "playful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dawn_of_Hope.mp3",
+    "moods": [
+      "hopeful",
+      "uplifting",
+      "inspiring",
+      "triumphant"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_-_A_Town_Called_Hometown.mp3",
+    "moods": [
+      "peaceful",
+      "nostalgic",
+      "warm",
+      "gentle"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_-_Basement.mp3",
+    "moods": [
+      "creepy",
+      "atmospheric",
+      "ominous",
+      "mysterious"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_-_Before_the_Story.mp3",
+    "moods": [
+      "bright",
+      "hopeful",
+      "magical",
+      "gentle"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_-_Dogtarune_aka_Dogcheck.mp3",
+    "moods": [
+      "whimsical",
+      "chaotic",
+      "comedic",
+      "quirky"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_-_Field_of_Hopes_and_Dreams.mp3",
+    "moods": [
+      "hopeful",
+      "adventurous",
+      "uplifting",
+      "magical"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_-_Friendship.mp3",
+    "moods": [
+      "warm",
+      "sweet",
+      "playful",
+      "gentle"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_-_Hip_Shop.mp3",
+    "moods": [
+      "funky",
+      "groovy",
+      "chill",
+      "playful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_-_Laura_Shigihara_-_Dont_Forget.mp3",
+    "moods": [
+      "comforting",
+      "bittersweet",
+      "gentle",
+      "hopeful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_-_The_Chase.mp3",
+    "moods": [
+      "frantic",
+      "urgent",
+      "chaotic",
+      "fast-paced"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_-_The_Door.mp3",
+    "moods": [
+      "tense",
+      "ominous",
+      "mysterious",
+      "dramatic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_-_Thrash_Rating.mp3",
+    "moods": [
+      "aggressive",
+      "loud",
+      "chaotic",
+      "energetic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_Gallery.mp3",
+    "moods": [
+      "chill",
+      "reflective",
+      "bittersweet",
+      "nostalgic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_Gallery_Extended.mp3",
+    "moods": [
+      "chill",
+      "reflective",
+      "bittersweet",
+      "nostalgic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_OST_School.mp3",
+    "moods": [
+      "cheerful",
+      "bright",
+      "simple",
+      "relaxed"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Deltarune_UST_KNIGHT.mp3",
+    "moods": [
+      "ominous",
+      "dark",
+      "epic",
+      "foreboding"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Desperate_Assault.mp3",
+    "moods": [
+      "aggressive",
+      "urgent",
+      "intense",
+      "relentless"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Destinys_Force_DS_ver.mp3",
+    "moods": [
+      "determined",
+      "energetic",
+      "driving",
+      "heroic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Destinys_Union.mp3",
+    "moods": [
+      "triumphant",
+      "uplifting",
+      "emotional",
+      "hopeful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Destructor_A_remake_of_Lena_Raines_Creator.mp3",
+    "moods": [
+      "intense",
+      "energetic",
+      "aggressive",
+      "mechanical"
+    ],
     "source": "filename inference"
   },
   {
-    "filename": "dragon castle___makai symphony - dragon castle_ is under a creative commons (by-nc 3.0) license_ @makai-symphony   music powered by breakingcopyright_    • 🔥 epic battle music .mp3",
-    "moods": ["epic", "fighting", "intense", "orchestral"],
+    "filename": "Disappeared.mp3",
+    "moods": [
+      "haunting",
+      "melancholic",
+      "mysterious",
+      "uneasy"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dismiss.mp3",
+    "moods": [
+      "abrupt",
+      "comedic",
+      "short",
+      "blunt"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Distortion_of_Time.mp3",
+    "moods": [
+      "disorienting",
+      "atmospheric",
+      "tense",
+      "unsettling"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Distortion_of_Time_Extended.mp3",
+    "moods": [
+      "disorienting",
+      "atmospheric",
+      "tense",
+      "unsettling"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dont_Do_It.mp3",
+    "moods": [
+      "tense",
+      "dramatic",
+      "urgent",
+      "rock-infused"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dont_Do_It_-_Are_You_Ready_To_Start_The_Procedure.mp3",
+    "moods": [
+      "menacing",
+      "taunting",
+      "tense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dont_Do_It_-_Cake_Dispensary.mp3",
+    "moods": [
+      "sarcastic",
+      "tense",
+      "dramatic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dont_Do_It_-_Didnt_Think_Youd_Fall_For_That.mp3",
+    "moods": [
+      "mocking",
+      "triumphant",
+      "dramatic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dont_Do_It_-_Plug_Me_In.mp3",
+    "moods": [
+      "desperate",
+      "urgent",
+      "intense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dont_Do_It_-_Press_The_Button.mp3",
+    "moods": [
+      "urgent",
+      "insistent",
+      "building"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dont_Do_It_-_Something_Stronger_Than_A_Portal_Gun.mp3",
+    "moods": [
+      "menacing",
+      "dark",
+      "dramatic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dont_Do_It_-_Stalemate_Detected.mp3",
+    "moods": [
+      "tense",
+      "suspenseful",
+      "ominous"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dont_Do_It_-_Stalemate_Resolved.mp3",
+    "moods": [
+      "urgent",
+      "chaotic",
+      "frantic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dont_Do_It_-_You_Were_Busy_Back_There.mp3",
+    "moods": [
+      "mocking",
+      "taunting",
+      "tense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dont_Do_It_-_Your_Old_Friend_Neurotoxin.mp3",
+    "moods": [
+      "menacing",
+      "ominous",
+      "cold"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dont_Make_a_Sound_-_Spiral_Knights_OST.mp3",
+    "moods": [
+      "stealthy",
+      "tense",
+      "suspenseful",
+      "cautious"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dreiton.mp3",
+    "moods": [
+      "awe-inspiring",
+      "atmospheric",
+      "expansive",
+      "nostalgic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Droopy_likes_ricochet.mp3",
+    "moods": [
+      "quirky",
+      "playful",
+      "calm",
+      "whimsical"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Droopy_likes_your_face.mp3",
+    "moods": [
+      "quirky",
+      "playful",
+      "upbeat",
+      "whimsical"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Dry_Hands.mp3",
+    "moods": [
+      "ambient",
+      "minimal",
+      "melancholic",
+      "sparse"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Duel_Hearts.mp3",
+    "moods": [
+      "passionate",
+      "confrontational",
+      "energetic",
+      "fiery"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Eisoptrophobia.mp3",
+    "moods": [
+      "haunting",
+      "fractured",
+      "dark",
+      "unsettling"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Empyrea_-_Ivory.mp3",
+    "moods": [
+      "ethereal",
+      "uplifting",
+      "euphoric",
+      "soaring"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Enemy_Approaching_Extended.mp3",
+    "moods": [
+      "urgent",
+      "tense",
+      "energetic",
+      "playful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Escape_Array_-_Half-Life_2_OST.mp3",
+    "moods": [
+      "tense",
+      "urgent",
+      "ambient"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Escaping_The_Void_-_Ivory.mp3",
+    "moods": [
+      "tense",
+      "atmospheric",
+      "hopeful",
+      "driving"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Extinction_Event_Horizon_-_Half-Life_2_OST.mp3",
+    "moods": [
+      "apocalyptic",
+      "ominous",
+      "desperate"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "FORGETTABLE_SMILE_-_Oricade.mp3",
+    "moods": [
+      "melancholic",
+      "reflective",
+      "bittersweet",
+      "emotional"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Fallen_Down_-_Undertale_OST.mp3",
+    "moods": [
+      "tender",
+      "melancholic",
+      "peaceful",
+      "wistful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Fallen_Down_-_Undertale_OST_Slowed_and_reverbed.mp3",
+    "moods": [
+      "dreamy",
+      "haunting",
+      "ethereal",
+      "melancholic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Fate_of_That_Day_-_Ivory.mp3",
+    "moods": [
+      "melancholic",
+      "reflective",
+      "somber",
+      "emotional"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Fever_Pitch_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "energetic",
+      "frantic",
+      "aggressive",
+      "intense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Final_Encounter_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "solemn",
+      "epic",
+      "determined",
+      "melancholic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Final_Fantasy_XV_OST_Creeping_Shadows.mp3",
+    "moods": [
+      "dark",
+      "ominous",
+      "stealthy",
+      "suspenseful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Final_Lament_-_Zolister.mp3",
+    "moods": [
+      "mournful",
+      "tragic",
+      "somber",
+      "desolate"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Flight_Hymn.mp3",
+    "moods": [
+      "epic",
+      "inspiring",
+      "triumphant",
+      "soaring"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Forlorn_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "sorrowful",
+      "lonely",
+      "haunting",
+      "melancholic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Friend_-_ivorycello.mp3",
+    "moods": [
+      "warm",
+      "nostalgic",
+      "gentle",
+      "heartfelt"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Friend_reprise_-_ivorycello.mp3",
+    "moods": [
+      "bittersweet",
+      "nostalgic",
+      "tender",
+      "reflective"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Getting_Caught_-_ivorycello.mp3",
+    "moods": [
+      "panicked",
+      "urgent",
+      "tense",
+      "frantic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Getting_the_Thoughts_Out_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "somber",
+      "melancholic",
+      "reflective",
+      "lonely"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Gibberish_TPoT_intro_theme_-_coal_bones.mp3",
+    "moods": [
+      "quirky",
+      "whimsical",
+      "playful",
+      "wacky"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Gradual_Liquidation_Title_Screen.mp3",
+    "moods": [
+      "eerie",
+      "ominous",
+      "unsettling",
+      "tense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Greenpath.mp3",
+    "moods": [
+      "serene",
+      "magical",
+      "melancholic",
+      "beautiful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Guard_Down_-_Half-Life_2_OST.mp3",
+    "moods": [
+      "melancholy",
+      "action-oriented",
+      "intense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Guns_Blazing_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "intense",
+      "mechanical",
+      "urgent",
+      "relentless"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Halls_Of_Science_4.mp3",
+    "moods": [
+      "mysterious",
+      "industrial",
+      "eerie",
+      "ambient"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Harbinger_of_Chaos_MKs_Theme.mp3",
+    "moods": [
+      "chaotic",
+      "aggressive",
+      "ominous",
+      "intense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Hard_Sunshine.mp3",
+    "moods": [
+      "melancholy",
+      "beautiful",
+      "bittersweet"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Hard_Sunshine_1_captured_-_Hard_Light_Bridge_1.mp3",
+    "moods": [
+      "ethereal",
+      "glowing",
+      "warm"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Hard_Sunshine_2_smart_-_Hard_Light_Bridge_2.mp3",
+    "moods": [
+      "ethereal",
+      "glowing",
+      "serene"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Hard_Sunshine_3_pure_-_Hard_Light_Bridge_3.mp3",
+    "moods": [
+      "pure",
+      "radiant",
+      "peaceful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Haunted_Panels.mp3",
+    "moods": [
+      "eerie",
+      "mysterious",
+      "subdued"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Hazardous_Environments_-_Half-Life_2_OST.mp3",
+    "moods": [
+      "heroic",
+      "adventurous",
+      "anthemic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Hes_the_Iblis_Trigger.mp3",
+    "moods": [
+      "urgent",
+      "dramatic",
+      "alarming",
+      "revelatory"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Hopes_And_Dreams_Extended.mp3",
+    "moods": [
+      "triumphant",
+      "hopeful",
+      "uplifting",
+      "inspiring"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Horologium_-_ivorycello.mp3",
+    "moods": [
+      "mysterious",
+      "tense",
+      "anticipatory",
+      "dark"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Hostage_-_Connor.mp3",
+    "moods": [
+      "dark",
+      "tense",
+      "brooding",
+      "suspenseful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Hybernating_Evil.mp3",
+    "moods": [
+      "ominous",
+      "dark",
+      "threatening",
+      "foreboding"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Iggy_Death_Theme.mp3",
+    "moods": [
+      "sad",
+      "melancholic",
+      "beautiful",
+      "poignant"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Infinites_theme.mp3",
+    "moods": [
+      "arrogant",
+      "aggressive",
+      "powerful",
+      "menacing"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Infinites_theme_Epic_Edition_Slow_Mix.mp3",
+    "moods": [
+      "epic",
+      "grand",
+      "dramatic",
+      "intense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Its_Out_-_Ivory.mp3",
+    "moods": [
+      "frantic",
+      "urgent",
+      "panicked",
+      "chaotic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Its_Raining_Somewhere_Else.mp3",
+    "moods": [
+      "melancholic",
+      "bittersweet",
+      "calm",
+      "reflective"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Ivory_-_Peaceful_Residence.mp3",
+    "moods": [
+      "peaceful",
+      "calm",
+      "serene",
+      "tranquil"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Jawbone_-_ivorycello.mp3",
+    "moods": [
+      "aggressive",
+      "gritty",
+      "intense",
+      "menacing"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Justice_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "solemn",
+      "resolute",
+      "somber",
+      "determined"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Knights_Guild_-_Voxlblade_Remade_OST.mp3",
+    "moods": [
+      "heroic",
+      "medieval",
+      "adventurous",
+      "noble"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "LEminenza_Oscura_I.mp3",
+    "moods": [
+      "dark",
+      "epic",
+      "dramatic",
+      "foreboding"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "LEminenza_Oscura_II.mp3",
+    "moods": [
+      "dark",
+      "epic",
+      "intense",
+      "urgent"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "LG_Orbifold_-_Half-Life_2_OST.mp3",
+    "moods": [
+      "intense",
+      "urgent",
+      "chaotic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Lab_Practicum_-_Half-Life_2_OST.mp3",
+    "moods": [
+      "mysterious",
+      "ambient",
+      "contemplative"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Last Chance - Music for FlameFrags 0.mp3",
+    "moods": [
+      "intense",
+      "action",
+      "gaming"
+    ],
     "source": "filename inference"
   },
   {
-    "filename": "deer immaterial anbr adrian berenguer.mp3",
-    "moods": ["calm", "relaxing", "ambient"],
+    "filename": "Last_Breath.mp3",
+    "moods": [
+      "somber",
+      "heavy",
+      "tragic",
+      "resolute"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Last_Chance_-_Act_0_all_monitors_found.mp3",
+    "moods": [
+      "urgent",
+      "desperate",
+      "tense",
+      "determined"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Last_Chance_-_Act_0_all_monitors_found_Extended.mp3",
+    "moods": [
+      "urgent",
+      "desperate",
+      "tense",
+      "determined"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Legend_of_Zelda_Remix_Lost_Memories_Sacred_Grove.mp3",
+    "moods": [
+      "nostalgic",
+      "serene",
+      "wistful",
+      "mysterious"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Light_of_the_Worlds_Fanmade_KH_final_battle_theme.mp3",
+    "moods": [
+      "epic",
+      "hopeful",
+      "triumphant",
+      "emotional"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Lights_Theme_Epic_Version_by_CJ_Music.mp3",
+    "moods": [
+      "epic",
+      "dramatic",
+      "powerful",
+      "heroic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Little_Mouse_-_ivorycello.mp3",
+    "moods": [
+      "anxious",
+      "tense",
+      "uneasy",
+      "vulnerable"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Love_as_a_Construct.mp3",
+    "moods": [
+      "beautiful",
+      "haunting",
+      "melancholic",
+      "tender"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Machiavellian_Bach.mp3",
+    "moods": [
+      "classical",
+      "mechanical",
+      "precise"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Main_Menu_5_Steamworks_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "mechanical",
+      "mysterious",
+      "industrious",
+      "restless"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Medium_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "determined",
+      "adventurous",
+      "tense",
+      "driving"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Menu_-_Cooking_Mama_4_Kitchen_Magic_OST.mp3",
+    "moods": [
+      "cheerful",
+      "cute",
+      "upbeat",
+      "playful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Mephiles_Phase_1.mp3",
+    "moods": [
+      "tense",
+      "ominous",
+      "complex",
+      "dark"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Mephiles_Temptation.mp3",
+    "moods": [
+      "seductive",
+      "manipulative",
+      "eerie"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Mephiles_Whisper.mp3",
+    "moods": [
+      "creeping",
+      "subtle",
+      "foreboding",
+      "unsettling"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Mining_Co-ncussion.mp3",
+    "moods": [
+      "percussive",
+      "intense",
+      "determined",
+      "driving"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Mining_Co._-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "industrious",
+      "gritty",
+      "laborious",
+      "persistent"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Music_of_Fours_3D_Hand_Full_BfB_theme.mp3",
+    "moods": [
+      "synthwave",
+      "energetic",
+      "powerful",
+      "dramatic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Nooks_Cranny_-_Animal_Crossing_City_Folk_OST.mp3",
+    "moods": [
+      "whimsical",
+      "cheerful",
+      "bouncy",
+      "playful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Nooks_Cranny_-_Animal_Crossing_Gamecube_OST.mp3",
+    "moods": [
+      "cheerful",
+      "bouncy",
+      "nostalgic",
+      "lighthearted"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Nothing_but_the_Truth_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "somber",
+      "revelatory",
+      "melancholic",
+      "weighted"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Noxious_Descension_In_Search_of_a_Cure_-_Spiral_Knights_OST.mp3",
+    "moods": [
+      "dark",
+      "ominous",
+      "desperate",
+      "foreboding"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "OldBuilders_A.mp3",
+    "moods": [
+      "ancient",
+      "mysterious",
+      "grand",
+      "solemn"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "OldBuilders_B.mp3",
+    "moods": [
+      "ancient",
+      "mysterious",
+      "grand",
+      "solemn"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "OldBuilders_D.mp3",
+    "moods": [
+      "ancient",
+      "mysterious",
+      "grand",
+      "solemn"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "OldBuilders_E.mp3",
+    "moods": [
+      "ancient",
+      "mysterious",
+      "grand",
+      "solemn"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Omg_What_has_He_Done.mp3",
+    "moods": [
+      "chaotic",
+      "frantic",
+      "dramatic",
+      "intense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Omg_What_has_He_Done_Second_part_Extended.mp3",
+    "moods": [
+      "chaotic",
+      "frantic",
+      "dramatic",
+      "intense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Ones_Past..._-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "melancholic",
+      "contemplative",
+      "tragic",
+      "heavy"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Phineas_and_Ferb_-_Candace_Theme.mp3",
+    "moods": [
+      "upbeat",
+      "energetic",
+      "humorous",
+      "determined"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Plot_Twist_10_Song.mp3",
+    "moods": [
+      "emotional",
+      "dramatic",
+      "introspective",
+      "pop"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Portal_2_OST_The_Reunion.mp3",
+    "moods": [
+      "distorted",
+      "gritty",
+      "energetic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Procedural_Jiggle_Bone.mp3",
+    "moods": [
+      "quirky",
+      "electronic",
+      "mechanical"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Psychophant_-_Ivory.mp3",
+    "moods": [
+      "intense",
+      "aggressive",
+      "edgy",
+      "driving"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Rage_Awakened_BBS_ver.mp3",
+    "moods": [
+      "epic",
+      "intense",
+      "determined",
+      "vengeful",
+      "passionate"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Resonance_-_HOME.mp3",
+    "moods": [
+      "nostalgic",
+      "dreamy",
+      "bittersweet",
+      "longing"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Respite_Extended.mp3",
+    "moods": [
+      "gentle",
+      "bittersweet",
+      "nostalgic",
+      "tender"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Reunited.mp3",
+    "moods": [
+      "nostalgic",
+      "triumphant",
+      "emotional",
+      "hopeful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Rude_Buster.mp3",
+    "moods": [
+      "punchy",
+      "confident",
+      "energetic",
+      "determined"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Rumble_-_Ivory.mp3",
+    "moods": [
+      "driving",
+      "energetic",
+      "dark",
+      "hypnotic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "SPOILER_Caroline_Deleted.mp3",
+    "moods": [
+      "bittersweet",
+      "cathartic",
+      "reflective",
+      "melancholic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Sacred_Moon.mp3",
+    "moods": [
+      "mystical",
+      "serene",
+      "adventurous",
+      "ethereal"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Sacred_Moon_DS_ver.mp3",
+    "moods": [
+      "mystical",
+      "serene",
+      "adventurous",
+      "calm"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Say_Apple_Unused.mp3",
+    "moods": [
+      "quirky",
+      "playful",
+      "light",
+      "whimsical"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Sky_Verse_NCS_Release_-_Lieless_Luuna_Yarimov.mp3",
+    "moods": [
+      "exciting",
+      "energetic",
+      "euphoric",
+      "uplifting"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Sky_Verse_NCS_Release_-_Lieless_Luuna_Yarimov_Super_slowed.mp3",
+    "moods": [
+      "dreamy",
+      "dark",
+      "hazy",
+      "atmospheric"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Sky_Verse_NCS_Release_-_Lieless_Luuna_Yarimov_Ultra_slowed.mp3",
+    "moods": [
+      "dark",
+      "atmospheric",
+      "heavy",
+      "hypnotic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Skylander_Academy.mp3",
+    "moods": [
+      "heroic",
+      "uplifting",
+      "energetic",
+      "empowering"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Snowdin_Town_Extended.mp3",
+    "moods": [
+      "cozy",
+      "cheerful",
+      "festive",
+      "warm"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Snowfall_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "calm",
+      "peaceful",
+      "nostalgic",
+      "serene"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Snowy_Extended.mp3",
+    "moods": [
+      "cold",
+      "lonely",
+      "serene",
+      "bittersweet"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Solaris_Phase_1.mp3",
+    "moods": [
+      "epic",
+      "desperate",
+      "intense",
+      "heroic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Sombre_Reflection_-_Spiral_Knights_OST.mp3",
+    "moods": [
+      "somber",
+      "reflective",
+      "melancholic",
+      "peaceful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Starfish_-_ivorycello.mp3",
+    "moods": [
+      "whimsical",
+      "curious",
+      "light",
+      "playful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Start_Menu.mp3",
+    "moods": [
+      "hopeful",
+      "simple",
+      "mysterious",
+      "whimsical"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Taking_My_Whole_Life_Tonight_-_Oricade.mp3",
+    "moods": [
+      "energetic",
+      "emotional",
+      "urgent",
+      "passionate"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Tears_in_the_Rain.mp3",
+    "moods": [
+      "melancholic",
+      "atmospheric",
+      "pensive",
+      "cinematic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Technical_Difficulties.mp3",
+    "moods": [
+      "mysterious",
+      "subdued",
+      "orchestral"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Tensions_Tighten_-_ivorycello.mp3",
+    "moods": [
+      "tense",
+      "anxious",
+      "suspenseful",
+      "ominous"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_Arch-Illager.mp3",
+    "moods": [
+      "menacing",
+      "epic",
+      "dark",
+      "ominous"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_Confrontation_-_Spiral_Knights_OST.mp3",
+    "moods": [
+      "dramatic",
+      "intense",
+      "confrontational",
+      "urgent"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_End_-_Ivory.mp3",
+    "moods": [
+      "dramatic",
+      "final",
+      "somber",
+      "resolute"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_Human_Exploit_-_Ivory.mp3",
+    "moods": [
+      "dark",
+      "brooding",
+      "intense",
+      "relentless"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_Love_Of_The_Game_-_Dream_Productions.mp3",
+    "moods": [
+      "inspiring",
+      "uplifting",
+      "triumphant",
+      "energetic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_Prophecy_-_ivorycello.mp3",
+    "moods": [
+      "ominous",
+      "foreboding",
+      "mystical",
+      "grand"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_Resurrection_of_Mephiles.mp3",
+    "moods": [
+      "dramatic",
+      "triumphant",
+      "ominous",
+      "powerful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_Resurrection_of_Solaris.mp3",
+    "moods": [
+      "awe-inspiring",
+      "apocalyptic",
+      "grand"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_Reunion_-_Get_Your_Sixty_Bucks.mp3",
+    "moods": [
+      "frantic",
+      "desperate",
+      "urgent"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_Reunion_-_We_Just_Need_To_Relax.mp3",
+    "moods": [
+      "ironic",
+      "tense",
+      "frantic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_Reunion_In_game_ver.mp3",
+    "moods": [
+      "energetic",
+      "distorted",
+      "driving"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_Spire_OST_ver.mp3",
+    "moods": [
+      "atmospheric",
+      "mysterious",
+      "grand",
+      "soaring"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_Terminal_Zone.mp3",
+    "moods": [
+      "ominous",
+      "atmospheric",
+      "tense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "The_Wardens_Duty_OST_ver.mp3",
+    "moods": [
+      "determined",
+      "heroic",
+      "grand",
+      "steadfast"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Them_Days.mp3",
+    "moods": [
+      "nostalgic",
+      "reflective",
+      "warm",
+      "melancholic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Theres_A_Storm_-_Ivory.mp3",
+    "moods": [
+      "ominous",
+      "tense",
+      "impending",
+      "dark"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Through_the_Macro_Lens_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "quirky",
+      "playful",
+      "whimsical",
+      "lighthearted"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "ToastedReuben_A_32_bar_intro.mp3",
+    "moods": [
+      "warm",
+      "intimate",
+      "jazzy",
+      "smooth"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "ToastedReuben_B_32_bar_intro.mp3",
+    "moods": [
+      "warm",
+      "intimate",
+      "jazzy",
+      "smooth"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "ToastedReuben_E_32_bar_intro.mp3",
+    "moods": [
+      "warm",
+      "intimate",
+      "jazzy",
+      "smooth"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Traptanium_Kaos_Part_I.mp3",
+    "moods": [
+      "intense",
+      "chaotic",
+      "epic",
+      "dramatic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Traptanium_Kaos_Part_II.mp3",
+    "moods": [
+      "intense",
+      "chaotic",
+      "epic",
+      "dramatic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Traptanium_Kaos_Part_IV.mp3",
+    "moods": [
+      "intense",
+      "chaotic",
+      "epic",
+      "climactic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Treading_Lightly_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "tense",
+      "eerie",
+      "cautious",
+      "ominous"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Triple_Entanglement_-_Half-Life_2_OST.mp3",
+    "moods": [
+      "eerie",
+      "ominous",
+      "tense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Triple_Laser_Phase.mp3",
+    "moods": [
+      "haunting",
+      "bright",
+      "mystical"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Triple_Laser_Phase_-_Thermal_Discouragement_Beam_10A.mp3",
+    "moods": [
+      "building",
+      "layered",
+      "curious"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Triple_Laser_Phase_-_Thermal_Discouragement_Beam_10B.mp3",
+    "moods": [
+      "building",
+      "layered",
+      "intriguing"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Triple_Laser_Phase_-_Thermal_Discouragement_Beam_10C.mp3",
+    "moods": [
+      "complete",
+      "harmonious",
+      "triumphant"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Triple_Laser_Phase_pomchoms_ver.mp3",
+    "moods": [
+      "playful",
+      "upbeat",
+      "quirky"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Tumble_-_Agile_Accelerando.mp3",
+    "moods": [
+      "fast",
+      "energetic",
+      "playful",
+      "light"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Tumble_-_Breakneck_Boogie.mp3",
+    "moods": [
+      "fast",
+      "energetic",
+      "playful",
+      "upbeat"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Tumble_-_Chop_Chop.mp3",
+    "moods": [
+      "fast",
+      "energetic",
+      "playful",
+      "rhythmic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Tumble_-_Dashing_on_the_Double.mp3",
+    "moods": [
+      "fast",
+      "energetic",
+      "playful",
+      "upbeat"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Tumble_-_Double_Time.mp3",
+    "moods": [
+      "fast",
+      "energetic",
+      "playful",
+      "upbeat"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Tumble_-_Lickety_Split.mp3",
+    "moods": [
+      "fast",
+      "energetic",
+      "playful",
+      "upbeat"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Tumble_-_Nimbly_Does_It.mp3",
+    "moods": [
+      "fast",
+      "energetic",
+      "playful",
+      "light"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Tumble_-_Pronto.mp3",
+    "moods": [
+      "fast",
+      "energetic",
+      "playful",
+      "upbeat"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Tumble_-_Swift_Descent.mp3",
+    "moods": [
+      "fast",
+      "energetic",
+      "playful",
+      "rushed"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Tunetank_Windwalker.mp3",
+    "moods": [
+      "dramatic",
+      "epic",
+      "hopeful",
+      "uplifting",
+      "powerful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Undertale_Last_Breath_phase_3_theme.mp3",
+    "moods": [
+      "dramatic",
+      "intense",
+      "tragic",
+      "desperate"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Undertale_OST_Another_Medium.mp3",
+    "moods": [
+      "energetic",
+      "eerie",
+      "determined",
+      "playful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Undertale_OST_Dogsong.mp3",
+    "moods": [
+      "whimsical",
+      "goofy",
+      "bright",
+      "chaotic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Undertale_OST_Dogsong_Extended.mp3",
+    "moods": [
+      "whimsical",
+      "goofy",
+      "bright",
+      "chaotic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Undertale_OST_Home_Extended.mp3",
+    "moods": [
+      "nostalgic",
+      "peaceful",
+      "melancholic",
+      "warm"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Undertale_OST_Snowdin_Town.mp3",
+    "moods": [
+      "cozy",
+      "cheerful",
+      "festive",
+      "warm"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Undertale_OST_Spear_of_Justice.mp3",
+    "moods": [
+      "fighting",
+      "energetic",
+      "boss battle",
+      "powerful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Undertale_OST_Undertale.mp3",
+    "moods": [
+      "melancholic",
+      "hopeful",
+      "nostalgic",
+      "emotional"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Undertale_OST_sans.mp3",
+    "moods": [
+      "laid-back",
+      "lazy",
+      "jazzy",
+      "chill"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Undertale_True_Genocide_ost_Shattered_Dreams.mp3",
+    "moods": [
+      "haunting",
+      "broken",
+      "mournful",
+      "desolate"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Unleash_The_Beast_-_Ivory.mp3",
+    "moods": [
+      "aggressive",
+      "intense",
+      "powerful",
+      "ferocious"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Upon_The_Rock_-_Ivory.mp3",
+    "moods": [
+      "steadfast",
+      "determined",
+      "resilient",
+      "grounded"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Vs_Chimera_-_Crash_Mind_Over_Mutant_DS_OST.mp3",
+    "moods": [
+      "aggressive",
+      "intense",
+      "chaotic",
+      "urgent"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Vs_Exellers_Amy.EXE.mp3",
+    "moods": [
+      "intense",
+      "urgent",
+      "aggressive",
+      "relentless"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Vs_Exellers_Amy.EXE_Extended.mp3",
+    "moods": [
+      "intense",
+      "urgent",
+      "aggressive",
+      "relentless"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Warden_Escape_A.mp3",
+    "moods": [
+      "tense",
+      "urgent",
+      "frantic",
+      "desperate"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Warden_Escape_B.mp3",
+    "moods": [
+      "tense",
+      "urgent",
+      "frantic",
+      "desperate"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Warden_Escape_B_Extended.mp3",
+    "moods": [
+      "tense",
+      "urgent",
+      "frantic",
+      "desperate"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Warden_Escape_C.mp3",
+    "moods": [
+      "tense",
+      "urgent",
+      "frantic",
+      "desperate"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Werehog_Battle_Theme_-_Sonic_Unleashed_OST.mp3",
+    "moods": [
+      "feral",
+      "intense",
+      "aggressive",
+      "beastly"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Where_Dreams_Die.mp3",
+    "moods": [
+      "melancholic",
+      "somber",
+      "tragic",
+      "desolate"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Wii_Shopping_Channel_Remix_-_Nicky_Flowers.mp3",
+    "moods": [
+      "catchy",
+      "upbeat",
+      "lively",
+      "fun"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "Windmill Isle - Day.mp3",
+    "moods": [
+      "classic",
+      "adventure",
+      "calm"
+    ],
     "source": "filename inference"
   },
   {
-    "filename": "deep in the forest.mp3",
-    "moods": ["adventure", "calm", "mysterious"],
-    "source": "filename inference"
+    "filename": "Your_Precious_Moon.mp3",
+    "moods": [
+      "triumphant",
+      "climactic",
+      "awe-inspiring"
+    ],
+    "source": "web search"
   },
   {
-    "filename": "corneria.mp3",
-    "moods": ["classic", "adventure", "upbeat"],
-    "source": "filename inference"
+    "filename": "Your_Precious_Moon_-_Manual_Core_Replacement_Required.mp3",
+    "moods": [
+      "urgent",
+      "desperate",
+      "triumphant"
+    ],
+    "source": "web search"
   },
   {
-    "filename": "cjbeards - fire and thunder.mp3",
-    "moods": ["epic", "intense", "dramatic"],
-    "source": "filename inference"
+    "filename": "Your_Precious_Moon_-_PART_FIVE.mp3",
+    "moods": [
+      "triumphant",
+      "climactic",
+      "soaring"
+    ],
+    "source": "web search"
   },
   {
-    "filename": "chased by fate.mp3",
-    "moods": ["suspense", "intense", "dramatic"],
-    "source": "filename inference"
+    "filename": "Your_Precious_Moon_-_Please_Press_The_Stalemate_Resolution_Button.mp3",
+    "moods": [
+      "tense",
+      "urgent",
+      "desperate"
+    ],
+    "source": "web search"
   },
   {
-    "filename": "chaos construct (by azali).mp3",
-    "moods": ["chaotic", "intense", "dark"],
-    "source": "filename inference"
+    "filename": "Your_Precious_Moon_First_half_In_game_ver.mp3",
+    "moods": [
+      "building",
+      "desperate",
+      "hopeful"
+    ],
+    "source": "web search"
   },
   {
-    "filename": "camellia - the world revolving (camellia remix).mp3",
-    "moods": ["intense", "energetic", "electronic"],
-    "source": "filename inference"
+    "filename": "Zamasu_theme.mp3",
+    "moods": [
+      "arrogant",
+      "divine",
+      "menacing",
+      "powerful"
+    ],
+    "source": "web search"
   },
   {
-    "filename": "break free.mp3",
-    "moods": ["epic", "inspiring", "adventure"],
-    "source": "filename inference"
+    "filename": "Zamasu_theme_Extended.mp3",
+    "moods": [
+      "arrogant",
+      "divine",
+      "menacing",
+      "epic"
+    ],
+    "source": "web search"
   },
   {
-    "filename": "blizzard peaks - sonic rush adventure.mp3",
-    "moods": ["adventure", "classic", "energetic"],
-    "source": "filename inference"
+    "filename": "Zamasus_theme_PokeMixr92s_recreation.mp3",
+    "moods": [
+      "arrogant",
+      "divine",
+      "menacing",
+      "intense"
+    ],
+    "source": "web search"
   },
   {
-    "filename": "black mass.mp3",
-    "moods": ["dark", "ominous", "intense"],
-    "source": "filename inference"
+    "filename": "Zamasus_theme_remix_by_Gladius.mp3",
+    "moods": [
+      "arrogant",
+      "divine",
+      "intense",
+      "aggressive"
+    ],
+    "source": "web search"
   },
   {
-    "filename": "battle of birds and pigs.mp3",
-    "moods": ["fighting", "fun", "adventure"],
-    "source": "filename inference"
+    "filename": "ZoomPianoHouse_A.mp3",
+    "moods": [
+      "upbeat",
+      "energetic",
+      "jazzy",
+      "playful"
+    ],
+    "source": "web search"
   },
   {
-    "filename": "battle against an empire.mp3",
-    "moods": ["epic", "fighting", "dramatic"],
-    "source": "filename inference"
+    "filename": "ZoomPianoHouse_B.mp3",
+    "moods": [
+      "upbeat",
+      "energetic",
+      "jazzy",
+      "playful"
+    ],
+    "source": "web search"
   },
   {
-    "filename": "background music.mp3",
-    "moods": ["ambient", "calm", "relaxing"],
-    "source": "filename inference"
+    "filename": "ZoomPianoHouse_C.mp3",
+    "moods": [
+      "upbeat",
+      "energetic",
+      "jazzy",
+      "playful"
+    ],
+    "source": "web search"
   },
   {
-    "filename": "azali x arcerion - zephaniah.mp3",
-    "moods": ["epic", "intense"],
-    "source": "filename inference"
+    "filename": "ZoomPianoHouse_D.mp3",
+    "moods": [
+      "upbeat",
+      "energetic",
+      "jazzy",
+      "playful"
+    ],
+    "source": "web search"
   },
   {
-    "filename": "at the speed of light.mp3",
-    "moods": ["fast", "energetic", "adventure"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "apassionato orchestral dramatic music.mp3",
-    "moods": ["classic", "dramatic", "epic"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "anthony vega - johnny vespa.mp3",
-    "moods": ["classic", "energetic", "adventure"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "adventurous.mp3",
-    "moods": ["adventure", "inspiring", "epic"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "action suspense.mp3",
-    "moods": ["suspense", "intense", "dramatic"],
-    "source": "filename inference"
-  },
-  {
-    "filename": "action suspense 2.mp3",
-    "moods": ["suspense", "intense", "dramatic"],
+    "filename": "a shattered illusion.mp3",
+    "moods": [
+      "dramatic",
+      "emotional",
+      "mysterious"
+    ],
     "source": "filename inference"
   },
   {
     "filename": "ace - verdant green swans.mp3",
-    "moods": ["calm", "relaxing", "ambient"],
+    "moods": [
+      "calm",
+      "relaxing",
+      "ambient"
+    ],
     "source": "filename inference"
   },
   {
-    "filename": "a shattered illusion.mp3",
-    "moods": ["dramatic", "emotional", "mysterious"],
+    "filename": "action suspense 2.mp3",
+    "moods": [
+      "suspense",
+      "intense",
+      "dramatic"
+    ],
     "source": "filename inference"
   },
   {
-    "filename": "Windmill Isle - Day.mp3",
-    "moods": ["classic", "adventure", "calm"],
+    "filename": "action suspense.mp3",
+    "moods": [
+      "suspense",
+      "intense",
+      "dramatic"
+    ],
     "source": "filename inference"
   },
   {
-    "filename": "Last Chance - Music for FlameFrags 0.mp3",
-    "moods": ["intense", "action", "gaming"],
+    "filename": "adventurous.mp3",
+    "moods": [
+      "adventure",
+      "inspiring",
+      "epic"
+    ],
     "source": "filename inference"
+  },
+  {
+    "filename": "anthony vega - johnny vespa.mp3",
+    "moods": [
+      "classic",
+      "energetic",
+      "adventure"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "apassionato orchestral dramatic music.mp3",
+    "moods": [
+      "classic",
+      "dramatic",
+      "epic"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "at the speed of light.mp3",
+    "moods": [
+      "fast",
+      "energetic",
+      "adventure"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "azali x arcerion - zephaniah.mp3",
+    "moods": [
+      "epic",
+      "intense"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "background music.mp3",
+    "moods": [
+      "ambient",
+      "calm",
+      "relaxing"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "battle against an empire.mp3",
+    "moods": [
+      "epic",
+      "fighting",
+      "dramatic"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "battle of birds and pigs.mp3",
+    "moods": [
+      "fighting",
+      "fun",
+      "adventure"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "black mass.mp3",
+    "moods": [
+      "dark",
+      "ominous",
+      "intense"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "blizzard peaks - sonic rush adventure.mp3",
+    "moods": [
+      "adventure",
+      "classic",
+      "energetic"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "break free.mp3",
+    "moods": [
+      "epic",
+      "inspiring",
+      "adventure"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "camellia - the world revolving (camellia remix).mp3",
+    "moods": [
+      "intense",
+      "energetic",
+      "electronic"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "chaos construct (by azali).mp3",
+    "moods": [
+      "chaotic",
+      "intense",
+      "dark"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "chased by fate.mp3",
+    "moods": [
+      "suspense",
+      "intense",
+      "dramatic"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "cjbeards - fire and thunder.mp3",
+    "moods": [
+      "epic",
+      "intense",
+      "dramatic"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "clovek_-_ivorycello.mp3",
+    "moods": [
+      "mysterious",
+      "atmospheric",
+      "brooding"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "corneria.mp3",
+    "moods": [
+      "classic",
+      "adventure",
+      "upbeat"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "deep in the forest.mp3",
+    "moods": [
+      "adventure",
+      "calm",
+      "mysterious"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "deer immaterial anbr adrian berenguer.mp3",
+    "moods": [
+      "calm",
+      "relaxing",
+      "ambient"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "defun_botsbuildbots__botsbuildbots.mp3",
+    "moods": [
+      "chaotic",
+      "mechanical",
+      "whimsical",
+      "frantic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "defun_botsbuildbots__botsbuildbots_In_game_ver.mp3",
+    "moods": [
+      "chaotic",
+      "mechanical",
+      "whimsical",
+      "frantic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "dragon castle___makai symphony - dragon castle_ is under a creative commons (by-nc 3.0) license_ @makai-symphony   music powered by breakingcopyright_    \u2022 \ud83d\udd25 epic battle music .mp3",
+    "moods": [
+      "epic",
+      "fighting",
+      "intense",
+      "orchestral"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "dramatic violin.mp3",
+    "moods": [
+      "dramatic",
+      "intense",
+      "emotional"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "end of a long journey.mp3",
+    "moods": [
+      "adventure",
+      "emotional",
+      "reflective"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "happy energetic boogie fun.mp3",
+    "moods": [
+      "happy",
+      "energetic",
+      "fun",
+      "playful",
+      "bouncy"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "haunted mansion.mp3",
+    "moods": [
+      "spooky",
+      "mysterious",
+      "eerie",
+      "adventure"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "hope_instilled_-_Ivory.mp3",
+    "moods": [
+      "hopeful",
+      "uplifting",
+      "inspiring",
+      "bright"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "iby - dj b-duke.mp3",
+    "moods": [
+      "electronic",
+      "energetic"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "infraction - atlas.mp3",
+    "moods": [
+      "epic",
+      "cinematic",
+      "intense"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "journey through the woods.mp3",
+    "moods": [
+      "adventure",
+      "calm",
+      "mysterious"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "king pig and his manic minions.mp3",
+    "moods": [
+      "intense",
+      "fun",
+      "adventure"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "larch_-_whitepine_OST.mp3",
+    "moods": [
+      "serene",
+      "atmospheric",
+      "calm",
+      "natural"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "local forecast - kevin macleod.mp3",
+    "moods": [
+      "upbeat",
+      "jazzy",
+      "energetic",
+      "sprightly",
+      "danceable"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "mountain_ash.mp3",
+    "moods": [
+      "serene",
+      "natural",
+      "peaceful",
+      "gentle"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "mountain_ash_reprise.mp3",
+    "moods": [
+      "peaceful",
+      "gentle",
+      "reflective",
+      "warm"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "move like this - jules gaia.mp3",
+    "moods": [
+      "energetic",
+      "upbeat",
+      "groovy"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "new world.mp3",
+    "moods": [
+      "adventure",
+      "inspiring",
+      "epic"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "oh what a whirl - jules gaia.mp3",
+    "moods": [
+      "energetic",
+      "upbeat"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "orange marmalade.mp3",
+    "moods": [
+      "playful",
+      "happy",
+      "fun"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "playboi carti x yeat type beat - black.mp3",
+    "moods": [
+      "modern",
+      "trap",
+      "dark",
+      "intense"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "playboi carti x yeat type beat - enough.mp3",
+    "moods": [
+      "modern",
+      "trap",
+      "energetic"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "playboi carti x yeat type beat - explosion.mp3",
+    "moods": [
+      "modern",
+      "trap",
+      "intense",
+      "aggressive"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "playboi carti x yeat type beat - prey.mp3",
+    "moods": [
+      "modern",
+      "trap",
+      "aggressive"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "playboi carti x yeat type beat - sega+.mp3",
+    "moods": [
+      "modern",
+      "trap",
+      "energetic"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "playboi carti x yeat type beat - sh\u00e4d\u00f6w.mp3",
+    "moods": [
+      "modern",
+      "trap",
+      "intense"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "popcorn castle.mp3",
+    "moods": [
+      "playful",
+      "happy",
+      "whimsical"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "qbedwars music.mp3",
+    "moods": [
+      "gaming",
+      "intense",
+      "action"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "quo vadis.mp3",
+    "moods": [
+      "classic",
+      "dramatic",
+      "epic",
+      "oratorio"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "run fast instrumental.mp3",
+    "moods": [
+      "energetic",
+      "action",
+      "upbeat",
+      "motivational",
+      "intense"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "shake down - jules gaia.mp3",
+    "moods": [
+      "energetic",
+      "driving"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "sparkling stars.mp3",
+    "moods": [
+      "calm",
+      "dreamy",
+      "relaxing"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "subconscious_-_Undertale_Yellow_OST.mp3",
+    "moods": [
+      "eerie",
+      "unsettling",
+      "dreamlike",
+      "creepy"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "synthatiger - beyond the grid.mp3",
+    "moods": [
+      "synthwave",
+      "electronic",
+      "retro",
+      "energetic",
+      "adventure"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "the_diadem_pt.1_-_Ivory.mp3",
+    "moods": [
+      "regal",
+      "mysterious",
+      "grand",
+      "ceremonial"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "the_diadem_pt.2_-_Ivory.mp3",
+    "moods": [
+      "triumphant",
+      "regal",
+      "grand",
+      "celebratory"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "toad factory - mario kart wii.mp3",
+    "moods": [
+      "classic",
+      "upbeat",
+      "racing",
+      "energetic"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "totally not a rickroll.mp3",
+    "moods": [
+      "happy",
+      "energetic",
+      "fun"
+    ],
+    "source": "filename inference"
+  },
+  {
+    "filename": "undertale ost spear of justice.mp3",
+    "moods": [
+      "fighting",
+      "energetic",
+      "boss battle",
+      "powerful"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "unstoppable force.mp3",
+    "moods": [
+      "heroic",
+      "epic",
+      "intense",
+      "driving",
+      "aggressive"
+    ],
+    "source": "web search"
+  },
+  {
+    "filename": "welcome to chaos - ross bugden.mp3",
+    "moods": [
+      "chaotic",
+      "intense",
+      "dark"
+    ],
+    "source": "web search"
   }
 ]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter, Routes, Route, Navigate, useLocation } from "react-route
 import VercelAnalytics from "@/components/VercelAnalytics";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { AuthProvider } from "@/providers/AuthProvider";
+import { useAuth } from "@/hooks/useAuth";
 import { HelmetProvider } from "react-helmet-async";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { IconLoader2 } from "@tabler/icons-react";
@@ -77,6 +78,13 @@ const LoadingFallback = ({ message = "Loading..." }: { message?: string }) => (
   </div>
 );
 
+const HomeRedirect = () => {
+  const { user, loading } = useAuth();
+  if (loading) return <LoadingFallback />;
+  if (user) return <Navigate to="/resources" replace />;
+  return <Index />;
+};
+
 const App = () => {
   const [queryClient] = useState(() => new QueryClient());
 
@@ -102,7 +110,7 @@ const App = () => {
               <BrowserRouter>
                 <Suspense fallback={<LoadingFallback />}>
                   <Routes>
-                    <Route path="/" element={<Index />} />
+                    <Route path="/" element={<HomeRedirect />} />
                     <Route path="/resources" element={<ResourcesHub />} />
                     <Route path="/contact" element={<Contact />} />
                     <Route

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -212,12 +212,6 @@ const Footer = () => {
                   <span className="ml-1 px-1.5 py-0.5 bg-cow-purple text-white text-[10px] rounded align-middle">NEW</span>
                 </Link>
               </li>
-              <li>
-                <Link to="/ai-title-helper" className="text-white/70 hover:text-white transition-colors flex items-center">
-                  <span>AI Title Helper</span>
-                  <span className="ml-1 px-1.5 py-0.5 bg-cow-purple text-white text-[10px] rounded align-middle">NEW</span>
-                </Link>
-              </li>
             </ul>
           </div>
         </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -9,7 +9,6 @@ const toolPaths = [
   '/player-renderer',
   '/text-generator',
   '/youtube-downloader',
-  '/ai-title-helper',
   '/generators',
 ]
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -63,9 +63,7 @@ const mainLinks: (NavLink | NavDropdown)[] = [
       { name: 'Player Renderer', path: '/player-renderer', icon: 'player' },
       { name: 'Text Generator', path: '/text-generator', icon: 'text' },
       { name: 'Youtube Tools', path: '/youtube-downloader', icon: 'yt-downloader', tag: 'NEW' },
-      { name: 'AI Title Helper', path: '/ai-title-helper', icon: 'text', tag: 'NEW' },
-      { name: 'Content Generators', path: '/generators', icon: 'text' },
-      { name: 's0', path: 'https://s0.renderdragon.org/docs', icon: 'external', tag: 'NEW' }
+      { name: 'Content Generators', path: '/generators', icon: 'text' }
     ]
   }
 ];
@@ -95,19 +93,6 @@ const Navbar = () => {
   const { user, loading, signOut } = useAuth(); // Added for auth
   const { profile } = useProfile();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false); // Manages Drawer open state
-  const [showBlogsBanner, setShowBlogsBanner] = useState(true);
-
-  // Initialize banner state from localStorage
-  useEffect(() => {
-    const hidden = localStorage.getItem('hideBlogsBanner');
-    if (hidden === '1') setShowBlogsBanner(false);
-  }, []);
-
-  const dismissBanner = () => {
-    setShowBlogsBanner(false);
-    localStorage.setItem('hideBlogsBanner', '1');
-  };
-
   useEffect(() => {
     let ticking = false;
     const handleScroll = () => {
@@ -196,29 +181,10 @@ const Navbar = () => {
 
   return (
     <>
-      {showBlogsBanner && (
-        <div className="fixed top-0 left-0 right-0 z-[60]">
-          <div className="w-full bg-gradient-to-r from-cow-purple/90 via-cow-purple to-cow-purple/90 text-white">
-            <div className="container mx-auto px-4 py-2 flex items-center justify-center gap-3 text-sm">
-              <span className="font-sans">Check out our new</span>
-              <Link to="/blogs" className="underline underline-offset-2 font-sans">
-                Blogs feature!
-              </Link>
-              <button
-                aria-label="Dismiss"
-                onClick={dismissBanner}
-                className="ml-3 text-white/80 hover:text-white"
-              >
-                <IconX className="w-4 h-4" />
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
       <header
         className={`fixed w-full z-50 transition-all duration-300 py-4 ${scrolled ? 'shadow-lg' : ''
           }`}
-        style={{ top: showBlogsBanner ? 36 : 0 }}
+        style={{ top: 0 }}
       >
         <div
           className={`absolute inset-0 z-[-1] pointer-events-none transition-all duration-300 ${isTransparent

--- a/src/components/resources/ResourceCard.tsx
+++ b/src/components/resources/ResourceCard.tsx
@@ -22,6 +22,10 @@ interface ResourceCardProps {
 const ResourceCard = ({ resource, onClick }: ResourceCardProps) => {
   const [isImageLoaded, setIsImageLoaded] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
+  const [hoverToPlay] = useState(() => {
+    const stored = localStorage.getItem('hoverToPlay');
+    return stored === null ? false : stored === 'true';
+  });
   const { user } = useAuth();
 
   // Reset image loaded state when resource changes
@@ -190,7 +194,7 @@ const ResourceCard = ({ resource, onClick }: ResourceCardProps) => {
           </div>
         );
       case "animations":
-        return isHovered ? (
+        return isHovered && hoverToPlay ? (
           <div
             onClick={handlePreviewClick}
             className="relative aspect-video bg-muted/20 rounded-md overflow-hidden mb-3 cursor-default"
@@ -283,7 +287,7 @@ const ResourceCard = ({ resource, onClick }: ResourceCardProps) => {
       </div>
 
       <motion.h3
-        className="text-xl font-jetbrains-mono mb-2 group-hover:text-primary transition-colors"
+        className="text-xl font-geist-mono mb-2 group-hover:text-primary transition-colors"
         whileHover={{ x: 5 }}
         transition={{ duration: 0.2 }}
       >

--- a/src/lib/showcases.ts
+++ b/src/lib/showcases.ts
@@ -106,19 +106,14 @@ export async function getShowcasesWithProfiles(search?: string): Promise<Showcas
   const legacyIds = showcases.filter(s => !s.id.startsWith('new-')).map(s => s.user_id);
   const newEmails = showcases.filter(s => s.id.startsWith('new-')).map(s => s.user_id);
 
-  const profilesMap: Record<string, { display_name?: string | null; avatar_url?: string | null; email?: string | null; username?: string | null }> = {};
+  const profilesMap: Record<string, { display_name?: string | null; avatar_url?: string | null; username?: string | null }> = {};
 
   if (legacyIds.length > 0 || newEmails.length > 0) {
-    let query = sb.from("profiles").select("id, display_name, email, avatar_url, username");
+    let query = sb.from("profiles").select("id, display_name, avatar_url, username");
 
     const conditions: string[] = [];
     if (legacyIds.length > 0) {
       conditions.push(`id.in.(${legacyIds.join(',')})`);
-    }
-    if (newEmails.length > 0) {
-      // Emails need to be quoted for PostgREST filter syntax
-      const quotedEmails = newEmails.map(e => `"${e}"`).join(',');
-      conditions.push(`email.in.(${quotedEmails})`);
     }
 
     if (conditions.length > 0) {
@@ -129,9 +124,7 @@ export async function getShowcasesWithProfiles(search?: string): Promise<Showcas
 
     if (data) {
       for (const row of (data as any[])) {
-        // Populate map for both ID and Email to ensure lookup works
         if (row.id) profilesMap[row.id] = row;
-        if (row.email) profilesMap[row.email] = row;
       }
     }
   }

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -27,7 +27,7 @@ const Account = () => {
   const [isUpdating, setIsUpdating] = useState(false);
   const [hoverToPlay, setHoverToPlay] = useState(() => {
     const stored = localStorage.getItem('hoverToPlay');
-    return stored === null ? true : stored === 'true';
+    return stored === null ? false : stored === 'true';
   });
   const avatarSrc: string | undefined =
     profile?.avatar_url ??

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -52,7 +52,7 @@ const ProfilePage: React.FC = () => {
         if (!username) return;
         const { data, error } = await supabase
           .from("profiles")
-          .select("id, email, display_name, avatar_url, username, bio, links, theme_config, social_links, verified")
+          .select("id, display_name, avatar_url, username, bio, links, social_links, verified")
           .eq("username", username)
           .maybeSingle();
 

--- a/supabase/migrations/20260703000000_add_profiles_public_select_policy.sql
+++ b/supabase/migrations/20260703000000_add_profiles_public_select_policy.sql
@@ -1,10 +1,14 @@
--- Enable RLS on profiles table (idempotent)
+-- Ensure RLS is enabled on profiles
 ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
 
--- Drop existing policy if it exists to avoid conflicts
+-- Allow public read access to profiles (required for foreign-key joins from creator_packs, blogs, etc.)
+-- Column-level REVOKE below prevents exposure of sensitive columns
 DROP POLICY IF EXISTS "Public profiles are viewable by everyone" ON profiles;
-
--- Allow anyone to read public profile fields (username, display_name, avatar_url)
 CREATE POLICY "Public profiles are viewable by everyone" ON profiles
 FOR SELECT
 USING (true);
+
+-- Revoke SELECT on sensitive profile columns from anonymous users.
+-- This prevents the REST API from exposing email, internal settings, etc.,
+-- while still allowing the RLS policy (USING true) to resolve foreign-key joins.
+REVOKE SELECT(email, first_name, last_name, theme_config, social_links, created_at, updated_at) ON profiles FROM anon;

--- a/supabase/migrations/20260703000000_add_profiles_public_select_policy.sql
+++ b/supabase/migrations/20260703000000_add_profiles_public_select_policy.sql
@@ -1,0 +1,10 @@
+-- Enable RLS on profiles table (idempotent)
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+-- Drop existing policy if it exists to avoid conflicts
+DROP POLICY IF EXISTS "Public profiles are viewable by everyone" ON profiles;
+
+-- Allow anyone to read public profile fields (username, display_name, avatar_url)
+CREATE POLICY "Public profiles are viewable by everyone" ON profiles
+FOR SELECT
+USING (true);


### PR DESCRIPTION
- Add 345 new music tracks with mood classifications to music library
- Disable hover-to-play for videos by default (opt-in via Account settings)
- Fix creator packs not showing for anonymous users (profiles RLS policy)
- Remove blogs banner from navbar
- Remove AI Title Helper and s0 from Tools dropdown and footer
- Change ResourceCard title font to Geist Mono
- Redirect signed-in users to /resources on home page visit
- Update changelog with all latest changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more music tracks with mood-based tagging and source info.
  * Signed-in users now go to the resources page from the home page.
  * Updated navigation with new tool links and cleaner menu options.

* **Bug Fixes**
  * Creator packs now work properly for visitors who aren’t signed in.
  * Fixed public profile visibility so profile pages load as expected.

* **Style**
  * Updated resource card titles to use a new mono font.
  * Video hover-to-play is now off by default, with an option to turn it back on in preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->