### PR TITLE
fix: TDZ crash on resources page, remove allowPlayBeforeReady for min…

### DIFF
--- a/src/components/resources/ResourceCard.tsx
+++ b/src/components/resources/ResourceCard.tsx
@@ -202,7 +202,6 @@ const ResourceCard = ({ resource, onClick }: ResourceCardProps) => {
             <AudioPlayer
               src={previewUrl}
               isInView={isInView}
-              allowPlayBeforeReady
               className="w-full shadow-none border-none bg-transparent p-0"
             />
           </div>

--- a/src/pages/ResourcesHub.tsx
+++ b/src/pages/ResourcesHub.tsx
@@ -43,9 +43,6 @@ const ResourcesHub = () => {
   const [mobileMoodFilterOpen, setMobileMoodFilterOpen] = useState(false);
   const [musicView, setMusicView] = useState<'community' | 'minecraft'>('community');
 
-  const minecraftMusic = useMinecraftMusic(isMinecraftMusicView);
-
-
   const {
     resources,
     selectedResource,
@@ -79,6 +76,8 @@ const ResourcesHub = () => {
   const isMcIconsView = selectedCategory === 'minecraft-icons';
   const isMusicView = selectedCategory === 'music';
   const isMinecraftMusicView = isMusicView && musicView === 'minecraft';
+
+  const minecraftMusic = useMinecraftMusic(isMinecraftMusicView);
 
   const [musicMoodsData, setMusicMoodsData] = useState<MusicMood[]>([]);
 


### PR DESCRIPTION
…ecraft-music

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio preview behavior for Minecraft music resources.
  * Fixed a resources hub loading issue by adjusting component initialization order, helping the page render more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->