### PR TITLE
fix: production CORS 401, guarded bindSupabase, prod WISP_SECRET

### DIFF
--- a/convex/dashboard.ts
+++ b/convex/dashboard.ts
@@ -237,8 +237,9 @@ export const getMachineStats = query({
 
     const errorNames = await ctx.db
       .query("events")
-      .withIndex("by_machine_time", (q) => q.eq("machineId", machineId))
-      .filter((q) => q.eq(q.field("type"), "error"))
+      .withIndex("by_machine_type_time", (q) =>
+        q.eq("machineId", machineId).eq("type", "error")
+      )
       .collect();
     const topErrors = Array.from(
       errorNames.reduce((map, e) => map.set(e.name, (map.get(e.name) ?? 0) + 1), new Map<string, number>())
@@ -249,8 +250,9 @@ export const getMachineStats = query({
 
     const pageviews = await ctx.db
       .query("events")
-      .withIndex("by_machine_time", (q) => q.eq("machineId", machineId))
-      .filter((q) => q.eq(q.field("type"), "pageview"))
+      .withIndex("by_machine_type_time", (q) =>
+        q.eq("machineId", machineId).eq("type", "pageview")
+      )
       .collect();
     const topPages = Array.from(
       pageviews.reduce((map, e) => map.set(e.url, (map.get(e.url) ?? 0) + 1), new Map<string, number>())

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -16,7 +16,14 @@ http.route({
   method: "POST",
   handler: httpAction(async (ctx, request) => {
     if (!isAuthorized(request)) {
-      return new Response("Unauthorized", { status: 401 });
+      return new Response("Unauthorized", {
+        status: 401,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "POST, OPTIONS",
+          "Access-Control-Allow-Headers": "Content-Type, x-wisp-token",
+        },
+      });
     }
 
     const body = await request.json() as { events: unknown[] };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -66,6 +66,7 @@ export default defineSchema({
     .index("by_session", ["sessionId"])
     .index("by_type_time", ["type", "timestamp"])
     .index("by_machine_time", ["machineId", "timestamp"])
+    .index("by_machine_type_time", ["machineId", "type", "timestamp"])
     .searchIndex("search_name", { searchField: "name", filterFields: ["type"] }),
 
   dailyStats: defineTable({

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -10,8 +10,13 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        // Bind Supabase auth state to Wisp analytics identity
-        const unsubscribeWisp = bindSupabase(supabase);
+        // Bind Supabase auth state to Wisp analytics identity (no-op if wisp not initialized)
+        let unsubscribeWisp = () => {};
+        try {
+            unsubscribeWisp = bindSupabase(supabase);
+        } catch {
+            // wisp not initialized — skip analytics identity binding
+        }
 
         // Set up auth state listener FIRST
         const {


### PR DESCRIPTION
- Add CORS headers to 401 response in /ingest so browser shows real error instead of CORS failure
- Guard bindSupabase in try/catch so it doesn't crash when wisp isn't initialized (e.g. VITE_CONVEX_URL not set)
- Set WISP_SECRET on production convex deployment precious-crocodile-678
- Deployed backend code to production deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `/ingest` endpoint’s unauthorized response so it now includes CORS headers, helping clients handle failed requests more consistently.
  * Made the app more resilient when analytics integration is unavailable, preventing startup/runtime issues and keeping authentication flows stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->