### PR TITLE
fix: prevent wisp Not initialized errors from bindSupabase

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,15 +9,12 @@ import '@fontsource/geist-mono';
 import '@fontsource/jetbrains-mono';
 
 import wisp, { init } from "@renderdragonorg/wisp";
-import { bindSupabase } from "@renderdragonorg/wisp/supabase";
-import { supabase } from "@/integrations/supabase/client";
 
 const convexUrl = import.meta.env.VITE_CONVEX_URL;
 const wispSecret = import.meta.env.VITE_WISP_SECRET;
 
 if (convexUrl) {
   init({ convexUrl, wispSecret: wispSecret || undefined });
-  bindSupabase(supabase);
 }
 
 // expose for console debugging

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -4,13 +4,16 @@ import { supabase } from "@/integrations/supabase/client";
 import { AuthContext, AuthResult } from "@/providers/AuthContext";
 import wisp from "@renderdragonorg/wisp";
 
-function tryIdentify(userId: string) {
-    try { wisp.identify(userId); } catch { /* wisp not initialized */ }
+function tryIdentify(userId: string, retries = 3) {
+    try { wisp.identify(userId); }
+    catch {
+        if (retries > 0) setTimeout(() => tryIdentify(userId, retries - 1), 500);
+    }
 }
 function tryReset() {
     try { wisp.reset(); } catch { /* wisp not initialized */ }
 }
-function tryTrackIdentify(session: Session | null) {
+function tryTrackIdentify(session: Session | null, retries = 3) {
     const user = session?.user;
     if (!user?.id) return;
     try {
@@ -22,7 +25,9 @@ function tryTrackIdentify(session: Session | null) {
             name: meta.full_name as string | undefined,
             provider: primaryIdentity?.provider ?? user.app_metadata?.provider ?? "email",
         });
-    } catch { /* wisp not initialized */ }
+    } catch {
+        if (retries > 0) setTimeout(() => tryTrackIdentify(session, retries - 1), 500);
+    }
 }
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -2,6 +2,29 @@ import { useState, useEffect } from "react";
 import { User, Session } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
 import { AuthContext, AuthResult } from "@/providers/AuthContext";
+import wisp from "@renderdragonorg/wisp";
+
+function tryIdentify(userId: string) {
+    try { wisp.identify(userId); } catch { /* wisp not initialized */ }
+}
+function tryReset() {
+    try { wisp.reset(); } catch { /* wisp not initialized */ }
+}
+function tryTrackIdentify(session: Session | null) {
+    const user = session?.user;
+    if (!user?.id) return;
+    try {
+        const meta = user.user_metadata as Record<string, unknown> || {};
+        const identities = (user.identities ?? []) as Array<{ provider?: string | null }>;
+        const primaryIdentity = identities.find((i) => i.provider === (user.app_metadata?.provider as string)) ?? identities[0];
+        wisp.track("session_identify", {
+            email: user.email,
+            name: meta.full_name as string | undefined,
+            provider: primaryIdentity?.provider ?? user.app_metadata?.provider ?? "email",
+        });
+    } catch { /* wisp not initialized */ }
+}
+
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const [user, setUser] = useState<User | null>(null);
     const [session, setSession] = useState<Session | null>(null);
@@ -14,12 +37,23 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
             setSession(session);
             setUser(session?.user ?? null);
             setLoading(false);
+
+            if (event === "SIGNED_IN" && session?.user.id) {
+                tryIdentify(session.user.id);
+                tryTrackIdentify(session);
+            } else if (event === "SIGNED_OUT") {
+                tryReset();
+            }
         });
 
         supabase.auth.getSession().then(({ data: { session } }) => {
             setSession(session);
             setUser(session?.user ?? null);
             setLoading(false);
+            if (session?.user.id) {
+                tryIdentify(session.user.id);
+                tryTrackIdentify(session);
+            }
         });
 
         return () => subscription.unsubscribe();


### PR DESCRIPTION
- Remove bindSupabase() call — its onAuthStateChange callback lacks try-catch and throws when wisp init timing is delayed
- Restore manual tryIdentify/tryReset with try-catch guards in AuthProvider, matching the original safe pattern
- Keep metadata enrichment: track session_identify event with email/name/provider on sign-in and existing session recovery