### PR TITLE
feat: add Minecraft-style fonts and apply site-wide

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -66,12 +66,12 @@ const Footer = () => {
           <div className="col-span-1 md:col-span-2">
             <Link
               to="/"
-              className="flex items-center space-x-2 text-xl font-bold mb-4"
+              className="inline-flex items-center gap-2 text-xl font-bold mb-4"
             >
               <div className="flex items-center justify-center">
                 <Logo size="sm" />
               </div>
-              <span className="font-minecraftia">Renderdragon</span>
+              <span className="font-minecraftia leading-none">RenderDragon</span>
             </Link>
 
             <p className="text-white/70 mb-6 max-w-md">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -195,13 +195,13 @@ const Navbar = () => {
         <div className="container mx-auto px-4 flex justify-between items-center relative z-10">
           <Link
             to="/"
-            className="flex items-center space-x-2 text-xl md:text-2xl font-bold tracking-wider"
+            className="inline-flex items-center gap-2 text-xl md:text-2xl font-bold tracking-wider"
           >
             <div className="flex items-center justify-center">
               <Logo size={isMobile ? "sm" : "md"} />
             </div>
             {!isMobile && (
-              <span className="hidden md:inline font-minecraftia">Render<span className="text-cow-purple">Dragon</span></span>
+              <span className="hidden md:inline font-minecraftia leading-none">Render<span className="text-cow-purple">Dragon</span></span>
             )}
             {isMobile && <span className="font-minecraftia">R<span className="text-cow-purple">D</span></span>}
           </Link>

--- a/src/components/generators/MinecraftNametagGenerator.tsx
+++ b/src/components/generators/MinecraftNametagGenerator.tsx
@@ -60,7 +60,7 @@ const MinecraftNametagGenerator = () => {
             <div className="flex items-center justify-center h-full">
               {playerName ? (
                 <span 
-                  className="font-pixel text-[28px] text-white leading-[1] whitespace-nowrap"
+                  className="font-mojangles text-[28px] text-white leading-[1] whitespace-nowrap"
                   style={{
                     textShadow: `
                       1px 0 0 #000000,
@@ -96,4 +96,4 @@ const MinecraftNametagGenerator = () => {
   );
 };
 
-export default MinecraftNametagGenerator; 
+export default MinecraftNametagGenerator;

--- a/src/components/generators/MinecraftNametagGenerator.tsx
+++ b/src/components/generators/MinecraftNametagGenerator.tsx
@@ -13,8 +13,9 @@ const MinecraftNametagGenerator = () => {
     // The preview updates automatically through state
   };
 
-  const exportAsPNG = () => {
+  const exportAsPNG = async () => {
     if (nametagContainerRef.current) {
+      await document.fonts.load('28px "Minecraft Seven"', playerName);
       html2canvas(nametagContainerRef.current, {
         scale: 3,
         logging: false,

--- a/src/index.css
+++ b/src/index.css
@@ -3,14 +3,14 @@
 @tailwind utilities;
 
 @font-face {
-  font-family: 'Minecraftia';
-  src: url('https://raw.githubusercontent.com/Yxmura/resources_renderdragon/main/fonts/minecraftia.ttf') format('truetype');
+  font-family: Minecraftia;
+  src: url('https://raw.githubusercontent.com/Yxmura/resources_renderdragon/d41fc385c3c178527da0710ad4f6cd4f37a12eea/fonts/minecraftia.ttf') format('truetype');
   font-display: swap;
 }
 
 @font-face {
   font-family: 'Minecraft Seven';
-  src: url('https://raw.githubusercontent.com/Yxmura/resources_renderdragon/main/fonts/minecraft.ttf') format('truetype');
+  src: url('https://raw.githubusercontent.com/Yxmura/resources_renderdragon/d41fc385c3c178527da0710ad4f6cd4f37a12eea/fonts/minecraft.ttf') format('truetype');
   font-display: swap;
 }
 
@@ -182,7 +182,7 @@
 }
 
 .font-minecraftia {
-  font-family: 'Minecraftia', monospace;
+  font-family: Minecraftia, monospace;
 }
 
 .font-mojangles {

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
+@font-face {
+  font-family: 'Minecraftia';
+  src: url('https://raw.githubusercontent.com/Yxmura/resources_renderdragon/main/fonts/minecraftia.ttf') format('truetype');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Minecraft Seven';
+  src: url('https://raw.githubusercontent.com/Yxmura/resources_renderdragon/main/fonts/minecraft.ttf') format('truetype');
+  font-display: swap;
+}
+
 @layer base {
   :root {
     --background: 230 20% 98%;
@@ -167,6 +179,14 @@
 
 .font-pixel {
   font-family: 'Press Start 2P', cursive;
+}
+
+.font-minecraftia {
+  font-family: 'Minecraftia', monospace;
+}
+
+.font-mojangles {
+  font-family: 'Minecraft Seven', monospace;
 }
 
 .font-jetbrains-mono {

--- a/src/pages/BackgroundGenerator.tsx
+++ b/src/pages/BackgroundGenerator.tsx
@@ -34,7 +34,7 @@ const isTexture = (value: unknown): value is Texture => {
 const BackgroundGenerator = () => {
   const [color, setColor] = useState("#9b87f5");
   const [size, setSize] = useState("1920x1080");
-  const [spacing, setSpacing] = useState([10]);
+  const [spacing, setSpacing] = useState([0]);
   const [opacity, setOpacity] = useState([100]);
   const [scale, setScale] = useState([100]);
   const [isTransparent, setIsTransparent] = useState(false);

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -416,7 +416,7 @@ const Community = () => {
                             <div className="bg-card p-4 flex justify-between items-center cursor-pointer hover:bg-accent/30 transition-colors">
                               <div className="flex-1">
                                 <div className="flex items-center gap-3">
-                                  <h2 className="text-2xl font-jetbrains-mono">
+                                  <h2 className="text-2xl font-minecraftia">
                                     {category.name}
                                   </h2>
                                   <Badge

--- a/src/pages/PlayerRenderer.tsx
+++ b/src/pages/PlayerRenderer.tsx
@@ -256,7 +256,7 @@ const PlayerRenderer = () => {
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                   {/* Mineatar Renders */}
                   <div className="pixel-card flex flex-col">
-                    <h1 className='text-center'>Body</h1>
+                    <h1 className='text-center font-minecraftia'>Body</h1>
                     <div className="aspect-square relative">
                       <img
                         src={renderUrls.mineatar.full(playerData.id)}
@@ -285,7 +285,7 @@ const PlayerRenderer = () => {
                   </div>
 
                   <div className="pixel-card flex flex-col">
-                    <h1 className='text-center'>Head</h1>
+                    <h1 className='text-center font-minecraftia'>Head</h1>
                     <div className="aspect-square relative">
                       <img
                         src={renderUrls.nmsr.face(playerData.id)}
@@ -315,7 +315,7 @@ const PlayerRenderer = () => {
 
                   {/* VZGE Render */}
                   <div className="pixel-card flex flex-col">
-                    <h1 className='text-center'>Bust (isometric)</h1>
+                    <h1 className='text-center font-minecraftia'>Bust (isometric)</h1>
                     <div className="aspect-square relative">
                       <img
                         src={renderUrls.nmsr.bust(playerData.id)}
@@ -345,7 +345,7 @@ const PlayerRenderer = () => {
 
                   {/* NMSR Renders */}
                   <div className="pixel-card flex flex-col">
-                    <h2 className='text-center'>Full Render (isometric)</h2>
+                    <h2 className='text-center font-minecraftia'>Full Render (isometric)</h2>
                     <div className="aspect-square relative">
                       <img
                         src={renderUrls.nmsr.fullbody(playerData.id)}

--- a/src/pages/Utilities.tsx
+++ b/src/pages/Utilities.tsx
@@ -195,14 +195,15 @@ const Utils = () => {
       </Helmet>
       <Navbar />
       
-      <main className="container mx-auto px-4 py-16 pt-24">
+      <main className="flex-grow cow-grid-bg">
+        <div className="container mx-auto px-4 py-16 pt-24">
         <motion.div 
           className="text-center mb-12"
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
         >
-          <h1 className="text-4xl md:text-5xl font-pixel mb-4">
+           <h1 className="text-4xl md:text-5xl font-minecraftia mb-4">
             Useful <span className="text-cow-purple">Utilities</span>
           </h1>
           <p className="text-muted-foreground max-w-2xl mx-auto">
@@ -279,6 +280,7 @@ const Utils = () => {
             </TabsContent>
           ))}
         </Tabs>
+        </div>
       </main>
 
       <Footer />

--- a/src/pages/YouTubeDownloader.tsx
+++ b/src/pages/YouTubeDownloader.tsx
@@ -282,7 +282,7 @@ const YouTubeDownloader: React.FC = () => {
 
             <Alert className="mb-8 pixel-corners">
               <IconInfoCircle className="h-4 w-4" />
-              <AlertTitle>Important Notice</AlertTitle>
+              <AlertTitle className="font-minecraftia">Important Notice</AlertTitle>
               <AlertDescription>
                 This tool is for educational purposes only. You are responsible for ensuring you have the right to download
                 and use any content.


### PR DESCRIPTION
- register Minecraftia and Minecraft Seven @font-face rules
- add font-minecraftia/font-mojangles utilities
- apply new fonts to brand, headings, and labels
- align brand text with leading-none and gap spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated branding, navigation, and footer spacing and typography.
  * Added Minecraft-inspired fonts and applied them across generator, community, renderer, utilities, and downloader pages.
  * Refined the Utilities page layout with a grid background and improved content structure.

* **Bug Fixes**
  * Corrected “RenderDragon” capitalization.
  * Background patterns now start with no spacing by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->