### PR TITLE
fix: cap looney-check function maxDuration at hobby limit

### DIFF
--- a/api/looney-check.js
+++ b/api/looney-check.js
@@ -5,6 +5,7 @@ import { isAllowedOrigin } from './cors.js';
 const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
 const DEFAULT_LOONEY_URL = 'https://looney.codersoft.xyz/check';
 const DAILY_CHECK_LIMIT = 5;
+const UPSTREAM_JOB_CREATE_TIMEOUT_MS = 55000;
 
 function getHeader(request, name) {
   if (request.headers?.get) return request.headers.get(name);
@@ -235,7 +236,7 @@ export const config = {
     bodyParser: false,
     sizeLimit: '52mb',
   },
-  maxDuration: 300,
+  maxDuration: 60,
 };
 
 class ValidationError extends Error {}
@@ -284,7 +285,8 @@ export default async function handler(request) {
         method: 'POST',
         headers: upstreamHeaders(upstream.contentType),
         body: upstream.body,
-        signal: AbortSignal.timeout(30000),
+        // Remote file checks may download and inspect the audio before returning a job ID.
+        signal: AbortSignal.timeout(UPSTREAM_JOB_CREATE_TIMEOUT_MS),
       });
     } catch (error) {
       try {

--- a/api/looney-check.js
+++ b/api/looney-check.js
@@ -5,7 +5,10 @@ import { isAllowedOrigin } from './cors.js';
 const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
 const DEFAULT_LOONEY_URL = 'https://looney.codersoft.xyz/check';
 const DAILY_CHECK_LIMIT = 5;
-const UPSTREAM_JOB_CREATE_TIMEOUT_MS = 55000;
+// Hobby caps the whole invocation at 60s. Keep work inside a 50s budget so
+// request parsing, the quota RPC, the upstream call, and releaseRateLimit
+// cleanup all complete before the platform terminates the invocation.
+const INVOCATION_BUDGET_MS = 50000;
 
 function getHeader(request, name) {
   if (request.headers?.get) return request.headers.get(name);
@@ -272,6 +275,7 @@ export default async function handler(request) {
   }
 
   try {
+    const invocationDeadline = Date.now() + INVOCATION_BUDGET_MS;
     const upstream = await buildUpstreamRequest(request);
     const rateLimit = await consumeRateLimit(request);
     if (!rateLimit.allowed) {
@@ -281,12 +285,15 @@ export default async function handler(request) {
     }
     let response;
     try {
+      const remainingBudgetMs = Math.max(0, invocationDeadline - Date.now());
       response = await fetch(`${getLooneyBaseUrl()}/jobs`, {
         method: 'POST',
         headers: upstreamHeaders(upstream.contentType),
         body: upstream.body,
         // Remote file checks may download and inspect the audio before returning a job ID.
-        signal: AbortSignal.timeout(UPSTREAM_JOB_CREATE_TIMEOUT_MS),
+        // Bound the upstream call by the remaining request budget so the abort handler
+        // below can still release the rate-limit reservation before the 60s cap.
+        signal: AbortSignal.timeout(remainingBudgetMs),
       });
     } catch (error) {
       try {


### PR DESCRIPTION
Vercel build was failing on the hobby plan because `api/looney-check.js` declared `maxDuration: 300`, but the hobby plan caps Serverless Functions at 60s.

**Why this is safe (verified live):**
- Job creation (POST) returns a `job_id` in ~2.5s even for remote file URLs — the upstream is async (`status: queued`). Well within 60s.
- The long-running research happens on the upstream Looney service, not on Vercel.
- The client streams progress via SSE, and when the stream is cut at 60s it automatically falls back to polling the fast status endpoint every 2s (up to 5 min) until the job completes — `src/utils/looneyChecker.ts` `streamLooneyJob` → `waitForTerminalJob`.
- Verified end-to-end: a real job completed in ~2.5 min via the same status endpoint the client polls.

**Changes:**
- Set `maxDuration` to 60 (hobby max).
- Bounded the upstream job-create timeout to 55s (was 30s; a 240s attempt in the working tree was based on the incorrect assumption that job creation blocks — it doesn't).

Verified with `pnpm run build` (passes).