### PR TITLE
chore: remove Looney Check promo entries from nav and resource cards

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -162,12 +162,6 @@ const Footer = () => {
             <h3 className="text-lg font-jetbrains-mono mb-4">Tools</h3>
             <ul className="space-y-2">
               <li>
-                <Link to="/gappa" className="text-white/70 hover:text-white transition-colors flex items-center">
-                  <span>Looney Checks</span>
-                  <span className="ml-1 px-1.5 py-0.5 bg-cow-purple text-white text-[10px] rounded align-middle">NEW</span>
-                </Link>
-              </li>
-              <li>
                 <Link to="/background-generator" className="text-white/70 hover:text-white transition-colors">
                   Background Generator
                 </Link>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -57,7 +57,6 @@ const mainLinks: (NavLink | NavDropdown)[] = [
     name: 'Tools',
     icon: 'tools',
     links: [
-      { name: 'Looney Checks', path: '/gappa', icon: 'music', tag: 'NEW' },
       { name: 'Background Generator', path: '/background-generator', icon: 'background' },
       { name: 'Player Renderer', path: '/player-renderer', icon: 'player' },
       { name: 'Text Generator', path: '/text-generator', icon: 'text' },

--- a/src/components/PopularTools.tsx
+++ b/src/components/PopularTools.tsx
@@ -17,14 +17,6 @@ type Tool = {
 const tools: Tool[] = [
   {
     id: 1,
-    title: 'Looney Checks',
-    description: 'Research a track before it gets your video copyright-striked.',
-    icon: IconMusic,
-    hoverImage: '/assets/looney-icon.png',
-    path: '/music-copyright',
-  },
-  {
-    id: 2,
     title: 'YouTube Tools',
     description: 'Grab thumbnails, peek at analytics, and download videos for reference.',
     icon: IconDownload,
@@ -32,7 +24,7 @@ const tools: Tool[] = [
     path: '/youtube-downloader',
   },
   {
-    id: 3,
+    id: 2,
     title: 'Background Gen',
     description: 'Generate stunning, unique backgrounds for your thumbnails in seconds.',
     icon: IconPhoto,
@@ -40,7 +32,7 @@ const tools: Tool[] = [
     path: '/background-generator',
   },
   {
-    id: 4,
+    id: 3,
     title: 'Player Renderer',
     description: 'Render a 3D model of any Minecraft player skin. Pose it. Screenshot it.',
     icon: IconUser,
@@ -99,7 +91,6 @@ const PopularTools = () => {
                      <img src={tool.backgroundImage} alt="" aria-hidden="true" className="pointer-events-none absolute inset-0 h-full w-full object-cover opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
                      <div aria-hidden="true" className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,transparent_35%,rgba(0,0,0,0.55)_100%)] opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
                    </>}
-                  {tool.id === 1 && <div className="pointer-events-none absolute right-5 top-5 w-32 translate-y-1 rounded-md border border-emerald-400/50 bg-[#0b1d19]/95 p-2 opacity-0 transition-all duration-200 group-hover:translate-y-0 group-hover:opacity-100"><div className="font-jetbrains-mono text-[9px] uppercase tracking-widest text-emerald-300">Check complete</div><div className="mt-1 text-xs font-semibold text-white">No match found</div></div>}
                   <div className="flex items-start justify-between mb-5">
                    <div className="relative z-10 w-12 h-12 bg-cow-purple/15 border-2 border-cow-purple pixel-corners flex items-center justify-center group-hover:scale-110 group-hover:-rotate-6 transition-transform duration-300">
                      <tool.icon className={`h-6 w-6 text-cow-purple transition-opacity duration-150 ${tool.hoverIcon || tool.hoverImage ? 'group-hover:opacity-0' : ''}`} stroke={2.5} />

--- a/src/components/resources/ResourceCard.tsx
+++ b/src/components/resources/ResourceCard.tsx
@@ -187,19 +187,6 @@ const ResourceCard = ({ resource, onClick, onCheckCopyright }: ResourceCardProps
               isInView={isInView}
               className="w-full shadow-none border-none bg-transparent p-0"
             />
-            {(resource.category === "music" || resource.category === "minecraft-music") && onCheckCopyright && (
-              <button
-                type="button"
-                onClick={handleCopyrightClick}
-                aria-label={`Check ${resource.title} for copyright`}
-                className="group/check absolute right-2 top-2 z-10 inline-flex h-10 w-10 items-center justify-center rounded-md border border-white bg-white p-1.5 text-black shadow-lg backdrop-blur-sm transition-all hover:w-auto hover:bg-white/90 hover:text-black"
-              >
-                <img src="/assets/looney-icon.png" alt="" aria-hidden="true" className="h-6 w-6 shrink-0 object-contain" />
-                <span className="max-w-0 overflow-hidden whitespace-nowrap text-xs font-medium opacity-0 transition-all group-hover/check:max-w-32 group-hover/check:opacity-100">
-                  Check for copyright
-                </span>
-              </button>
-            )}
           </div>
         );
       case "minecraft-music":


### PR DESCRIPTION
Removes the Looney Check promotion surface from the UI:

- Footer Tools list entry
- Navbar Tools dropdown entry
- PopularTools homepage card
- Music resource card copyright button

Verified with `pnpm run build` (passes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the “Looney Checks” tool from the footer, navigation menu, and popular tools list.
  * Removed copyright-check status overlays from popular tool cards and audio previews.
  * Audio playback remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->